### PR TITLE
Add tex and bib as language IDs

### DIFF
--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -23,8 +23,8 @@ impl Language {
 
     pub fn by_language_id(language_id: &str) -> Option<Self> {
         match language_id {
-            "latex" => Some(Language::Latex),
-            "bibtex" => Some(Language::Bibtex),
+            "latex" | "tex" => Some(Language::Latex),
+            "bibtex" | "bib" => Some(Language::Bibtex),
             _ => None,
         }
     }


### PR DESCRIPTION
Several LSP clients (such as vim's) send `tex` and `bib` as language IDs.
Thus, this improves client support.