### PR TITLE
Added support for Rnw files

### DIFF
--- a/src/tex/mod.rs
+++ b/src/tex/mod.rs
@@ -72,7 +72,7 @@ pub enum Language {
 impl Language {
     pub fn by_extension(extension: &str) -> Option<Self> {
         match extension.to_lowercase().as_str() {
-            "tex" | "sty" | "cls" | "def" | "lco" | "aux" => Some(Language::Latex),
+            "tex" | "sty" | "cls" | "def" | "lco" | "aux" | "rnw" => Some(Language::Latex),
             "bib" | "bibtex" => Some(Language::Bibtex),
             _ => None,
         }


### PR DESCRIPTION
Thanks for your awesome work! 

This is a very simple PR to add support to [Rnw files](https://support.rstudio.com/hc/en-us/articles/200532247-Weaving-Rnw-Files).
Rnw are mixed content files which contain R code.
I usually have chunks of R code to generate tables and figures within a latex document.

I looked for an alternative to force texlab to recognise the file but I realised that it has a hard-coded list of supported extensions. I have no idea if there are other extensions that use latex code but perhaps it would be good to add a flag to skip the extension check or a way to add new extensions as settings.