### PR TITLE
Swap deprecated ::fuzzy_matcher to ::SkimMatcherV2

### DIFF
--- a/src/completion/mod.rs
+++ b/src/completion/mod.rs
@@ -37,7 +37,8 @@ use crate::{
     workspace::DocumentContent,
 };
 use async_trait::async_trait;
-use fuzzy_matcher::skim::fuzzy_match;
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
 use std::collections::HashSet;
 
 pub const COMPLETION_LIMIT: usize = 50;
@@ -145,27 +146,28 @@ fn preselect(req: &FeatureRequest<CompletionParams>, items: &mut [Item]) {
 fn score(req: &FeatureRequest<CompletionParams>, items: &mut Vec<Item>) {
     let current_word = current_word(req);
     let pattern = current_word.as_deref().unwrap_or_default();
+    let matcher = SkimMatcherV2::default();
     for item in items {
         item.score = match &item.data {
-            ItemData::ComponentCommand { name, .. } => fuzzy_match(name, pattern),
-            ItemData::ComponentEnvironment { name, .. } => fuzzy_match(name, pattern),
-            ItemData::UserCommand { name } => fuzzy_match(name, pattern),
-            ItemData::UserEnvironment { name } => fuzzy_match(name, pattern),
-            ItemData::Label { text, .. } => fuzzy_match(&text, pattern),
-            ItemData::Class { name } => fuzzy_match(&name, pattern),
-            ItemData::Package { name } => fuzzy_match(&name, pattern),
-            ItemData::PgfLibrary { name } => fuzzy_match(name, pattern),
-            ItemData::TikzLibrary { name } => fuzzy_match(name, pattern),
-            ItemData::File { name } => fuzzy_match(name, pattern),
-            ItemData::Directory { name } => fuzzy_match(name, pattern),
-            ItemData::Citation { text, .. } => fuzzy_match(&text, pattern),
-            ItemData::Argument { name, .. } => fuzzy_match(&name, pattern),
-            ItemData::BeginCommand => fuzzy_match("begin", pattern),
-            ItemData::Color { name } => fuzzy_match(name, pattern),
-            ItemData::ColorModel { name } => fuzzy_match(name, pattern),
-            ItemData::GlossaryEntry { name } => fuzzy_match(name, pattern),
-            ItemData::EntryType { ty } => fuzzy_match(&ty.name, pattern),
-            ItemData::Field { field } => fuzzy_match(&field.name, pattern),
+            ItemData::ComponentCommand { name, .. } => matcher.fuzzy_match(name, pattern),
+            ItemData::ComponentEnvironment { name, .. } => matcher.fuzzy_match(name, pattern),
+            ItemData::UserCommand { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::UserEnvironment { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::Label { text, .. } => matcher.fuzzy_match(&text, pattern),
+            ItemData::Class { name } => matcher.fuzzy_match(&name, pattern),
+            ItemData::Package { name } => matcher.fuzzy_match(&name, pattern),
+            ItemData::PgfLibrary { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::TikzLibrary { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::File { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::Directory { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::Citation { text, .. } => matcher.fuzzy_match(&text, pattern),
+            ItemData::Argument { name, .. } => matcher.fuzzy_match(&name, pattern),
+            ItemData::BeginCommand => matcher.fuzzy_match("begin", pattern),
+            ItemData::Color { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::ColorModel { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::GlossaryEntry { name } => matcher.fuzzy_match(name, pattern),
+            ItemData::EntryType { ty } => matcher.fuzzy_match(&ty.name, pattern),
+            ItemData::Field { field } => matcher.fuzzy_match(&field.name, pattern),
         };
     }
 }


### PR DESCRIPTION
Fixes these warnings:
```
   Compiling texlab v2.2.0 (/home/user/.cargo/git/checkouts/texlab-91a739dcf08574b4/3b0db49)
warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
  --> src/completion/mod.rs:40:5
   |
40 | use fuzzy_matcher::skim::fuzzy_match;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:150:56
    |
150 |             ItemData::ComponentCommand { name, .. } => fuzzy_match(name, pattern),
    |                                                        ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:151:60
    |
151 |             ItemData::ComponentEnvironment { name, .. } => fuzzy_match(name, pattern),
    |                                                            ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:152:47
    |
152 |             ItemData::UserCommand { name } => fuzzy_match(name, pattern),
    |                                               ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:153:51
    |
153 |             ItemData::UserEnvironment { name } => fuzzy_match(name, pattern),
    |                                                   ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:154:45
    |
154 |             ItemData::Label { text, .. } => fuzzy_match(&text, pattern),
    |                                             ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:155:41
    |
155 |             ItemData::Class { name } => fuzzy_match(&name, pattern),
    |                                         ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:156:43
    |
156 |             ItemData::Package { name } => fuzzy_match(&name, pattern),
    |                                           ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:157:46
    |
157 |             ItemData::PgfLibrary { name } => fuzzy_match(name, pattern),
    |                                              ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:158:47
    |
158 |             ItemData::TikzLibrary { name } => fuzzy_match(name, pattern),
    |                                               ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:159:40
    |
159 |             ItemData::File { name } => fuzzy_match(name, pattern),
    |                                        ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:160:45
    |
160 |             ItemData::Directory { name } => fuzzy_match(name, pattern),
    |                                             ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:161:48
    |
161 |             ItemData::Citation { text, .. } => fuzzy_match(&text, pattern),
    |                                                ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:162:48
    |
162 |             ItemData::Argument { name, .. } => fuzzy_match(&name, pattern),
    |                                                ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:163:39
    |
163 |             ItemData::BeginCommand => fuzzy_match("begin", pattern),
    |                                       ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:164:41
    |
164 |             ItemData::Color { name } => fuzzy_match(name, pattern),
    |                                         ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:165:46
    |
165 |             ItemData::ColorModel { name } => fuzzy_match(name, pattern),
    |                                              ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:166:49
    |
166 |             ItemData::GlossaryEntry { name } => fuzzy_match(name, pattern),
    |                                                 ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:167:43
    |
167 |             ItemData::EntryType { ty } => fuzzy_match(&ty.name, pattern),
    |                                           ^^^^^^^^^^^

warning: use of deprecated item 'fuzzy_matcher::skim::fuzzy_match': Please use SkimMatcherV2 instead
   --> src/completion/mod.rs:168:42
    |
168 |             ItemData::Field { field } => fuzzy_match(&field.name, pattern),
    |                                          ^^^^^^^^^^^

```