### PR TITLE
Bump bibutils-sys to 0.1.1 (fixes build on Apple Silicon)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bibutils-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e96544dd4aadc8416a2fdd0205a886664b6eb0c17704de46c836373e9c515"
+checksum = "701178dfb147521ab87f4729feff1c21b69449b3f09fc263dd429aa43afb4f5c"
 dependencies = [
  "cc",
 ]
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cesu8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ required-features = ["test"]
 async-trait = "0.1"
 aovec = { version = "1.1", optional = true }
 base64 = "0.13"
-bibutils-sys = { version = "0.1", optional = true }
+bibutils-sys = { version = "0.1.1", optional = true }
 byteorder = "1.3"
 bytes = { version = "0.5", optional = true }
 chashmap = "2.2"


### PR DESCRIPTION
`bibutils-sys` 0.1.1 uses an updated version of the `cc` crate which correctly handles the translation between the `aarch64-apple-darwin` Rust target and the `arm64-apple-darwin` LLVM target.

I've confirmed it builds succesfully locally on my M1 MacBook.

Related: #343, Homebrew/homebrew-core#68404