### PR TITLE
Move `--locked` flag to after the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alternatively, Rust users can run the following command
 without having to clone this repository:
 
 ```shell
-cargo install --git --locked https://github.com/latex-lsp/texlab.git
+cargo install --git https://github.com/latex-lsp/texlab.git --locked
 ```
 
 ## Development


### PR DESCRIPTION
The command previously in the README won't actually run (since it assumes you are passing `--locked` to `--url`).