### PR TITLE
Do not try to match the full key in completion

### DIFF
--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -163,6 +163,7 @@ fn score(context: &CursorContext<CompletionParams>, items: &mut Vec<InternalComp
                 key.words()
                     .take_while(|word| word.text_range() != token.text_range())
                     .chain(std::iter::once(token))
+                    .take(10)
                     .join(" ")
                     .into()
             } else {

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -163,7 +163,6 @@ fn score(context: &CursorContext<CompletionParams>, items: &mut Vec<InternalComp
                 key.words()
                     .take_while(|word| word.text_range() != token.text_range())
                     .chain(std::iter::once(token))
-                    .take(10)
                     .filter(|word| word.text_range().start() < context.offset)
                     .join(" ")
                     .into()

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -164,6 +164,7 @@ fn score(context: &CursorContext<CompletionParams>, items: &mut Vec<InternalComp
                     .take_while(|word| word.text_range() != token.text_range())
                     .chain(std::iter::once(token))
                     .take(10)
+                    .filter(|word| word.text_range().start() < context.offset)
                     .join(" ")
                     .into()
             } else {

--- a/src/features/cursor.rs
+++ b/src/features/cursor.rs
@@ -267,9 +267,9 @@ impl<P: HasPosition> CursorContext<P> {
         key.map(|key| {
             let range = if group
                 .syntax()
-                .children_with_tokens()
-                .filter_map(|elem| elem.into_token())
-                .any(|tok| tok.kind() == latex::MISSING)
+                .last_token()
+                .filter(|tok| tok.kind() == latex::MISSING)
+                .is_some()
             {
                 TextRange::new(key.small_range().start(), token.text_range().end())
             } else {

--- a/src/syntax/latex/parser.rs
+++ b/src/syntax/latex/parser.rs
@@ -1531,6 +1531,11 @@ mod tests {
     }
 
     #[test]
+    fn test_label_reference_incomplete() {
+        assert_debug_snapshot!(setup(r#"Equation \eqref{eq is a \emph{useful} identity."#));
+    }
+
+    #[test]
     fn test_equation_label_reference_simple() {
         assert_debug_snapshot!(setup(r#"\eqref{foo}"#));
     }

--- a/src/syntax/latex/snapshots/texlab__syntax__latex__parser__tests__label_reference_incomplete.snap
+++ b/src/syntax/latex/snapshots/texlab__syntax__latex__parser__tests__label_reference_incomplete.snap
@@ -1,0 +1,33 @@
+---
+source: src/syntax/latex/parser.rs
+expression: "setup(r#\"Equation \\eqref{eq is a \\emph{useful} identity.\"#)"
+
+---
+ROOT@0..47
+  PREAMBLE@0..47
+    TEXT@0..9
+      WORD@0..8 "Equation"
+      WHITESPACE@8..9 " "
+    LABEL_REFERENCE@9..24
+      LABEL_REFERENCE_NAME@9..15 "\\eqref"
+      CURLY_GROUP_WORD_LIST@15..24
+        L_CURLY@15..16 "{"
+        KEY@16..24
+          WORD@16..18 "eq"
+          WHITESPACE@18..19 " "
+          WORD@19..21 "is"
+          WHITESPACE@21..22 " "
+          WORD@22..23 "a"
+          WHITESPACE@23..24 " "
+        MISSING@24..24 ""
+    GENERIC_COMMAND@24..38
+      GENERIC_COMMAND_NAME@24..29 "\\emph"
+      CURLY_GROUP@29..38
+        L_CURLY@29..30 "{"
+        TEXT@30..36
+          WORD@30..36 "useful"
+        R_CURLY@36..37 "}"
+        WHITESPACE@37..38 " "
+    TEXT@38..47
+      WORD@38..47 "identity."
+

--- a/tests/integration/completion.rs
+++ b/tests/integration/completion.rs
@@ -268,7 +268,7 @@ mod latex {
             "bibtex",
             false,
         )?;
-        assert_json_snapshot!(complete_and_resolve(&server, tex_uri, 3, 6)?);
+        assert_json_snapshot!(complete_and_resolve(&server, tex_uri, 3, 7)?);
         Ok(())
     }
 
@@ -549,7 +549,7 @@ mod latex {
             "latex",
             false,
         )?;
-        assert_json_snapshot!(complete_and_resolve(&server, uri, 5, 5)?);
+        assert_json_snapshot!(complete_and_resolve(&server, uri, 5, 6)?);
         Ok(())
     }
 
@@ -732,7 +732,7 @@ mod latex {
             "latex",
             false,
         )?;
-        assert_json_snapshot!(complete_and_resolve(&server, uri, 3, 7)?);
+        assert_json_snapshot!(complete_and_resolve(&server, uri, 3, 8)?);
         Ok(())
     }
 
@@ -790,7 +790,7 @@ mod latex {
             "latex",
             false,
         )?;
-        assert_json_snapshot!(complete_and_resolve(&server, uri, 4, 7)?);
+        assert_json_snapshot!(complete_and_resolve(&server, uri, 4, 8)?);
         Ok(())
     }
 }

--- a/tests/integration/issues.rs
+++ b/tests/integration/issues.rs
@@ -39,3 +39,23 @@ fn test_408_parent_expansion() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "completion")]
+fn test_510_completion_with_unmatched_braces() -> Result<()> {
+    use insta::assert_debug_snapshot;
+
+    let server = ServerTester::launch_new_instance()?;
+    server.initialize(ClientCapabilities::default(), None)?;
+
+    let uri = server.open(
+        "main.tex",
+        "\\label{eq:foo}\n\\ref{eq is a \\emph{useful} identity.",
+        "latex",
+        false,
+    )?;
+
+    assert_debug_snapshot!(server.complete(uri, 1, 7)?);
+
+    Ok(())
+}

--- a/tests/integration/snapshots/integration__issues__510_completion_with_unmatched_braces.snap
+++ b/tests/integration/snapshots/integration__issues__510_completion_with_unmatched_braces.snap
@@ -1,0 +1,57 @@
+---
+source: tests/integration/issues.rs
+expression: "server.complete(uri, 1, 7)?"
+
+---
+CompletionList {
+    is_incomplete: false,
+    items: [
+        CompletionItem {
+            label: "eq:foo",
+            kind: Some(
+                Text,
+            ),
+            detail: None,
+            documentation: None,
+            deprecated: None,
+            preselect: Some(
+                false,
+            ),
+            sort_text: Some(
+                "00 eq:foo",
+            ),
+            filter_text: Some(
+                "eq:foo",
+            ),
+            insert_text: None,
+            insert_text_format: None,
+            insert_text_mode: None,
+            text_edit: Some(
+                Edit(
+                    TextEdit {
+                        range: Range {
+                            start: Position {
+                                line: 1,
+                                character: 5,
+                            },
+                            end: Position {
+                                line: 1,
+                                character: 7,
+                            },
+                        },
+                        new_text: "eq:foo",
+                    },
+                ),
+            ),
+            additional_text_edits: None,
+            command: None,
+            commit_characters: None,
+            data: Some(
+                String(
+                    "label",
+                ),
+            ),
+            tags: None,
+        },
+    ],
+}


### PR DESCRIPTION
Instead only match the key up to the cursor position.

Fixes #510.