### PR TITLE
doc/previewing: fix Zathura key for SyncTeX Inverse Search

### DIFF
--- a/docs/previewing.md
+++ b/docs/previewing.md
@@ -129,7 +129,7 @@ set synctex true
 set synctex-editor-command "code -g %{input}:%{line}"
 ```
 
-You can execute the search by pressing `Alt+Click` in the PDF document.
+You can execute the search by pressing `Ctrl+Click` in the PDF document.
 
 ---
 


### PR DESCRIPTION
As discovered in https://github.com/kak-lsp/kak-lsp/pull/573#issuecomment-989350761
Zathura's shortcut for backward search is Ctrl+LMB
