### PR TITLE
Add support of binary for aarch64-apple-darwin(M1 mac) to GitHub release pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,25 +42,53 @@ jobs:
         include:
           - os: ubuntu-latest
             toolchain: stable
+            transpile_target: null
           - os: ubuntu-18.04
             toolchain: 1.53
+            transpile_target: null
           - os: windows-latest
             toolchain: stable
+            transpile_target: null
           - os: macos-latest
             toolchain: stable
+            transpile_target: null
+          - os: macos-latest
+            toolchain: stable
+            transpile_target: aarch64-apple-darwin
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Install Rust toolchain
+      - name: Install Rust toolchain for a native compiler
         uses: actions-rs/toolchain@v1
+        id: rust_toolchain_native
+        if: matrix.transpile_target == null
         with:
           toolchain: ${{ matrix.toolchain }}
           profile: minimal
           override: true
           components: rustfmt
+      - name: Install Rust toolchain for a cross compiler
+        uses: actions-rs/toolchain@v1
+        if: steps.rust_toolchain_native.conclusion == 'skipped'
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+          components: rustfmt
+          target: ${{ matrix.transpile_target }}
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-      - name: Compile
+      - name: Compile with a native compiler
+        id: rust_compile_native
+        if: matrix.transpile_target == null
         run: cargo test --no-run --locked
-      - name: Test
+      - name: Compile with a cross compiler
+        if: steps.rust_compile_native.conclusion == 'skipped'
+        run: cargo test --target ${{ matrix.transpile_target }} --no-run --locked
+      - name: Test with a native compiler
+        id: rust_test_native
+        if: matrix.transpile_target == null
         run: cargo test -- --nocapture --quiet
+      - name: Test with a cross compile
+        if: steps.rust_test_native.conclusion == 'skipped'
+        run: cargo test --target ${{ matrix.transpile_target }} -- --nocapture --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,3 @@ jobs:
         id: rust_test_native
         if: matrix.transpile_target == null
         run: cargo test -- --nocapture --quiet
-      - name: Test with a cross compile
-        if: steps.rust_test_native.conclusion == 'skipped'
-        run: cargo test --target ${{ matrix.transpile_target }} -- --nocapture --quiet

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,26 +9,44 @@ jobs:
       matrix:
         include:
           - os: ubuntu-18.04
+            transpile_target: null
             archive_file: texlab-x86_64-linux.tar.gz
             archive_cmd: tar -czvf {0} -C target/release texlab
             archive_type: application/gzip
           - os: windows-latest
+            transpile_target: null
             archive_file: texlab-x86_64-windows.zip
             archive_cmd: Compress-Archive target/release/texlab.exe {0}
             archive_type: application/zip
           - os: macos-latest
+            transpile_target: null
             archive_file: texlab-x86_64-macos.tar.gz
+            archive_cmd: brew install gnu-tar; gtar -czvf {0} -C target/release texlab
+            archive_type: application/gzip
+          - os: macos-11
+            transpile_target: aarch64-apple-darwin
+            archive_file: texlab-aarch64-macos.tar.gz
             archive_cmd: brew install gnu-tar; gtar -czvf {0} -C target/release texlab
             archive_type: application/gzip
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
+        id: rust_toolchain_native
+        if: matrix.transpile_target == null
         with:
           toolchain: stable
+          target: matrix.transpile_target
       - uses: actions-rs/cargo@v1
+        id: rust_build_native
+        if: matrix.transpile_target == null
         with:
           command: build
           args: --release --locked
+      - uses: actions-rs/cargo@v1
+        if: steps.rust_toolchain_native.conclusion == 'skipped'
+        with:
+          command: build
+          args: --release --locked --target ${{ matrix.transpile_target }}
       - run: ${{ format(matrix.archive_cmd, matrix.archive_file) }}
         name: "Compress release binary"
       - uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Add support of binary for `aarch64-apple-darwin`, which is related to #589.

What is not going well is
- [ ] I am not sure the way to test the aarch64-apple-darwin binary.
I wrote a job to check, but the cargo looks not adapt to test a cross compiler.
I can delete the job.

I would appreciate it if you could check this pull request and comment to my concern.