### PR TITLE
Fix typo in latex laxer: subimportfrom -> subinputfrom

### DIFF
--- a/src/syntax/latex/lexer.rs
+++ b/src/syntax/latex/lexer.rs
@@ -201,7 +201,7 @@ enum CommandNameToken {
     #[token("\\import")]
     #[token("\\subimport")]
     #[token("\\inputfrom")]
-    #[token("\\subimportfrom")]
+    #[token("\\subinputfrom")]
     #[token("\\includefrom")]
     #[token("\\subincludefrom")]
     Import,


### PR DESCRIPTION
The commands are `\inputfrom` and `\subinputfrom`