### PR TITLE
Update CI branches to prevent duplicate builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - develop
-      - feature/*
 env:
   CARGO_INCREMENTAL: 0
   CI: 1


### PR DESCRIPTION
Update the CI pipeline to run only for pull requests and the master branch.