### PR TITLE
Fix panic from diagnostics thread in tests

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -248,7 +248,9 @@ impl Server {
                             document,
                         };
 
-                        diag_sender.send(message).unwrap();
+                        if diag_sender.send(message).is_err() {
+                            break;
+                        }
                     }
                 };
             }


### PR DESCRIPTION
```
running 57 tests
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
stack backtrace:
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/server.rs:251:51
   0: rust_begin_unwind
             at /rustc/7737e0b5c410[32](https://github.com/latex-lsp/texlab/runs/6296068866?check_suite_focus=true#step:8:32)16d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/77[37](https://github.com/latex-lsp/texlab/runs/6296068866?check_suite_focus=true#step:8:37)e0b5c[41](https://github.com/latex-lsp/texlab/runs/6296068866?check_suite_focus=true#step:8:41)03216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:1[43](https://github.com/latex-lsp/texlab/runs/6296068866?check_suite_focus=true#step:8:43):14
   2: core::result::unwrap_failed
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/result.rs:1749:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/result.rs:1065:23
   4: texlab::server::Server::register_diagnostics_handler::{{closure}}
             at ./src/server.rs:251:25
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```