### PR TITLE
Add inlay hints for \label

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ itertools = "0.10.1"
 log = "0.4.17"
 logos = "0.12.1"
 lsp-server = "0.6.0"
-lsp-types = "0.93.1"
+lsp-types = { version = "0.93.1", features = ["proposed"] }
 notify = "5.0.0"
 once_cell = "1.14.0"
 regex = "1.6.0"

--- a/src/features.rs
+++ b/src/features.rs
@@ -8,6 +8,7 @@ mod formatting;
 mod forward_search;
 mod highlight;
 mod hover;
+mod inlay_hint;
 mod link;
 mod lsp_kinds;
 mod reference;
@@ -30,6 +31,7 @@ pub use self::{
     forward_search::{execute_forward_search, ForwardSearchResult, ForwardSearchStatus},
     highlight::find_document_highlights,
     hover::find_hover,
+    inlay_hint::find_inlay_hints,
     link::find_document_links,
     reference::find_all_references,
     rename::{prepare_rename_all, rename_all},

--- a/src/features/inlay_hint.rs
+++ b/src/features/inlay_hint.rs
@@ -1,0 +1,13 @@
+mod label;
+
+use lsp_types::{InlayHint, InlayHintParams};
+
+use self::label::find_label_inlay_hints;
+
+use super::FeatureRequest;
+
+pub fn find_inlay_hints(request: FeatureRequest<InlayHintParams>) -> Vec<InlayHint> {
+    let mut hints = Vec::new();
+    find_label_inlay_hints(&request, &mut hints);
+    hints
+}

--- a/src/features/inlay_hint/label.rs
+++ b/src/features/inlay_hint/label.rs
@@ -1,0 +1,51 @@
+use lsp_types::{InlayHint, InlayHintLabel, InlayHintParams};
+use rowan::ast::AstNode;
+
+use crate::{
+    features::FeatureRequest,
+    render_label,
+    syntax::latex::{self, LabelDefinition},
+    LineIndexExt,
+};
+
+pub fn find_label_inlay_hints(
+    request: &FeatureRequest<InlayHintParams>,
+    hints: &mut Vec<InlayHint>,
+) -> Option<()> {
+    let main_document = request.main_document();
+    let data = main_document.data.as_latex()?;
+    let root = latex::SyntaxNode::new_root(data.green.clone());
+
+    hints.extend(
+        root.descendants()
+            .filter_map(latex::LabelDefinition::cast)
+            .filter_map(|label| create_hint(request, &label)),
+    );
+
+    Some(())
+}
+
+fn create_hint(
+    request: &FeatureRequest<InlayHintParams>,
+    label: &LabelDefinition,
+) -> Option<InlayHint> {
+    let name = label.name().and_then(|group| group.key())?;
+
+    let rendered = render_label(&request.workspace, &name.to_string(), Some(label.clone()))?;
+
+    let position = request
+        .main_document()
+        .line_index
+        .line_col_lsp(name.syntax().text_range().end());
+
+    Some(InlayHint {
+        position,
+        label: InlayHintLabel::String(rendered.reference()),
+        kind: None,
+        text_edits: None,
+        tooltip: None,
+        padding_left: Some(true),
+        padding_right: None,
+        data: None,
+    })
+}

--- a/src/features/inlay_hint/label.rs
+++ b/src/features/inlay_hint/label.rs
@@ -16,9 +16,14 @@ pub fn find_label_inlay_hints(
     let data = main_document.data.as_latex()?;
     let root = latex::SyntaxNode::new_root(data.green.clone());
 
+    let range = main_document
+        .line_index
+        .offset_lsp_range(request.params.range);
+
     hints.extend(
         root.descendants()
             .filter_map(latex::LabelDefinition::cast)
+            .filter(|label| label.syntax().text_range().intersect(range).is_some())
             .filter_map(|label| create_hint(request, &label)),
     );
 

--- a/tests/integration/lsp/text_document.rs
+++ b/tests/integration/lsp/text_document.rs
@@ -7,6 +7,7 @@ mod document_symbol;
 mod folding_range;
 mod formatting;
 mod hover;
+mod inlay_hint;
 mod publish_diagnostics;
 mod references;
 mod rename;

--- a/tests/integration/lsp/text_document/inlay_hint.rs
+++ b/tests/integration/lsp/text_document/inlay_hint.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use insta::assert_json_snapshot;
+use lsp_types::{
+    request::InlayHintRequest, ClientCapabilities, InlayHint, InlayHintParams, Position, Range,
+    TextDocumentIdentifier,
+};
+
+use crate::lsp::{client::Client, fixture};
+
+fn check(fixture: &str) -> Result<Vec<InlayHint>> {
+    let mut client = Client::spawn()?;
+    client.initialize(ClientCapabilities::default(), None)?;
+
+    let fixture = fixture::parse(fixture);
+    let uri = client.uri(fixture.files[0].name)?;
+
+    for file in fixture.files {
+        client.open(file.name, file.lang, file.text)?;
+    }
+
+    let actual_hints = client
+        .request::<InlayHintRequest>(InlayHintParams {
+            text_document: TextDocumentIdentifier::new(uri),
+            range: Range::new(Position::new(0, 0), Position::new(12, 0)),
+            work_done_progress_params: Default::default(),
+        })?
+        .unwrap_or_default();
+
+    client.shutdown()?;
+
+    Ok(actual_hints)
+}
+
+#[test]
+fn label_definition() -> Result<()> {
+    assert_json_snapshot!(check(
+        r#"
+%TEX main.tex
+%SRC \documentclass{article}
+%SRC \usepackage{caption}
+%SRC \begin{document}
+%SRC \section{Foo}\label{sec:foo}
+%SRC \section{Bar}\label{sec:bar}
+%SRC \subsection{Baz}\label{sec:baz}
+%SRC \begin{figure}
+%SRC     Test
+%SRC     \label{fig:qux}
+%SRC     \caption{Qux}
+%SRC \end{figure}
+%SRC \end{document}
+
+%TEX main.aux
+%SRC \relax 
+%SRC \providecommand*\caption@xref[2]{\@setref\relax\@undefined{#1}}
+%SRC \newlabel{fig:qux}{{\caption@xref {fig:qux}{ on input line 15}}{1}}
+%SRC \@writefile{lof}{\contentsline {figure}{\numberline {1}{\ignorespaces Qux\relax }}{1}{}\protected@file@percent }
+%SRC \@writefile{toc}{\contentsline {section}{\numberline {1}Foo}{1}{}\protected@file@percent }
+%SRC \newlabel{sec:foo}{{1}{1}}
+%SRC \@writefile{toc}{\contentsline {section}{\numberline {2}Bar}{1}{}\protected@file@percent }
+%SRC \newlabel{sec:bar}{{2}{1}}
+%SRC \@writefile{toc}{\contentsline {subsection}{\numberline {2.1}Baz}{1}{}\protected@file@percent }
+%SRC \newlabel{sec:baz}{{2.1}{1}}
+%SRC \gdef \@abspage@last{1}
+"#,
+    )?);
+
+    Ok(())
+}

--- a/tests/integration/lsp/text_document/snapshots/integration__lsp__text_document__inlay_hint__label_definition.snap
+++ b/tests/integration/lsp/text_document/snapshots/integration__lsp__text_document__inlay_hint__label_definition.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration/lsp/text_document/inlay_hint.rs
+expression: "check(r#\"\n%TEX main.tex\n%SRC \\documentclass{article}\n%SRC \\usepackage{caption}\n%SRC \\begin{document}\n%SRC \\section{Foo}\\label{sec:foo}\n%SRC \\section{Bar}\\label{sec:bar}\n%SRC \\subsection{Baz}\\label{sec:baz}\n%SRC \\begin{figure}\n%SRC     Test\n%SRC     \\label{fig:qux}\n%SRC     \\caption{Qux}\n%SRC \\end{figure}\n%SRC \\end{document}\n\n%TEX main.aux\n%SRC \\relax \n%SRC \\providecommand*\\caption@xref[2]{\\@setref\\relax\\@undefined{#1}}\n%SRC \\newlabel{fig:qux}{{\\caption@xref {fig:qux}{ on input line 15}}{1}}\n%SRC \\@writefile{lof}{\\contentsline {figure}{\\numberline {1}{\\ignorespaces Qux\\relax }}{1}{}\\protected@file@percent }\n%SRC \\@writefile{toc}{\\contentsline {section}{\\numberline {1}Foo}{1}{}\\protected@file@percent }\n%SRC \\newlabel{sec:foo}{{1}{1}}\n%SRC \\@writefile{toc}{\\contentsline {section}{\\numberline {2}Bar}{1}{}\\protected@file@percent }\n%SRC \\newlabel{sec:bar}{{2}{1}}\n%SRC \\@writefile{toc}{\\contentsline {subsection}{\\numberline {2.1}Baz}{1}{}\\protected@file@percent }\n%SRC \\newlabel{sec:baz}{{2.1}{1}}\n%SRC \\gdef \\@abspage@last{1}\n\"#)?"
+---
+[
+  {
+    "position": {
+      "line": 3,
+      "character": 27
+    },
+    "label": "Section 1 (Foo)",
+    "paddingLeft": true
+  },
+  {
+    "position": {
+      "line": 4,
+      "character": 27
+    },
+    "label": "Section 2 (Bar)",
+    "paddingLeft": true
+  },
+  {
+    "position": {
+      "line": 5,
+      "character": 30
+    },
+    "label": "Subsection 2.1 (Baz)",
+    "paddingLeft": true
+  },
+  {
+    "position": {
+      "line": 8,
+      "character": 18
+    },
+    "label": "Figure fig:qux: Qux",
+    "paddingLeft": true
+  }
+]


### PR DESCRIPTION
This PR adds a basic implementation of the `InlayHint` request for `\label` commands (only the definition, not the reference).

See #753.