### PR TITLE
Add possibility to explicitly signal root directory

### DIFF
--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -161,6 +161,8 @@ const SPECIAL_ENTRIES: &[&str] = &[
     "latexmkrc",
     ".chktexrc",
     "chktexrc",
+    ".texlabroot",
+    "texlabroot",
 ];
 
 #[salsa::tracked]


### PR DESCRIPTION
An attempt to tackle #826.

# Scenario
I ran into #826 with a project structure like this:

<details>
<summary>Project Structure</summary>

```
meeting-notes
├── .git
├── .gitignore
├── 2022-07-13
│   └── notes.md
├── 2022-07-27
│   └── notes.md
├── 2022-08-10
│   ├── notes.md
│   ├── graphs.pdf
│   ├── multi-graph.pdf
│   └── simple-graph.pdf
├── 2022-08-24
│   ├── graphs.pdf
│   ├── document.pdf -> ../tex-doc/document.pdf
│   └── notes.md
├── 2022-09-07
│   ├── document.pdf -> ../tex-doc/document.pdf
│   └── notes.md
├── 2022-09-21
│   ├── document.pdf -> ../tex-doc/document.pdf
│   ├── notes.md
├── 2022-10-05
│   └── notes.md
├── 2022-10-19
│   └── notes.md
├── 2022-11-02
│   └── notes.md
├── 2022-11-16
│   └── notes.md
├── 2022-11-30
│   ├── document.pdf -> ../tex-doc/document.pdf
│   └── notes.md
├── 2022-12-14
│   └── notes.md
├── 2023-01-11
│   ├── document.pdf -> ../tex-doc/document.pdf
│   └── notes.md
└── tex-doc
    ├── document.aux
    ├── document.fdb_latexmk
    ├── document.fls
    ├── document.log
    ├── document.out
    ├── document.pdf
    ├── document.synctex.gz
    └── document.tex
```
</details>

I keep notes on biweekly meetings as Markdown files in a Git directory (see `tree` output above). Each meeting gets its own subdirectory so that I can also include other files that were relevant for the meeting. Additionally, some of these meeting directories have symlinks to a document located in the `tex-doc/` directory.

When editing `tex-doc/document.tex` and compiling using TexLab, TexLab tries to determine the root directory from file path. Since `meeting-notes/` is the first directory that includes one of the "special files" (the `.git/` directory in this case), it is set as the root for the project. Thus, the build artifacts are placed into `meeting-notes/` directly instead of `tex-doc/`, where I would like them to be.

# Proposed Change & Justification
Prior to this commit, TexLab searches for the following paths to determine "rootness" of a directory:
- `.git/`
- `Tectonic.toml`
- `.latexmkrc`
- `latexmkrc`
- `.chktexrc`
- `chktexrc`

## The Change
**My proposed solution is a simple one: in addition to the files above, TexLab also looks for the files `.texlabroot` and `texlabroot`.** These serve no purpose other than signaling to TexLab that this directory should be considered the project root. With this change, the project structure from above would look like this:
```
meeting-notes
├── .git
├── .gitignore
├── [omitted for brevity]
└── tex-doc
    ├── .texlabroot
    ├── document.aux
    ├── document.fdb_latexmk
    ├── document.fls
    ├── document.log
    ├── document.out
    ├── document.pdf
    ├── document.synctex.gz
    └── document.tex
```

Compilations of `tex-doc/document.tex` will then place the build artifacts into `tex-doc/` as desired.

<details>
<summary>Commit Message</summary>

> When a root directory is not directly specified in the config, TexLab traverses upwards in the file system hierarchy upwards until a .git directory or a latexmk/chktex/Tectonic configuration file is found. The first directory where one of the search items is found is then considered the root directory. This is a reasonable default but may not work for all project structures.
> 
> To provide more flexibility, this commit adds the possibility to explicitly signal when TexLab should stop searching for the root directory via empty ".texlabroot" or "texlabroot" files. These serve no purpose other than signaling to TexLab that it should stop traversing upwards at this point.
</details>

## The Justification
This solution is ...
- **flexible**: Users have complete control over when TexLab should stop looking for a root directory.
- **backwards-compatible**: For existing project structures, TexLab will still behave the same as it did before this change (i.e., nothing will break).
- **easy to maintain**: Since this solution leverages the existing root discovery algorithm, little additional code maintenance is required.

I think this solution would also help with the scenarios described in @har7an and @xlucn in #826, maybe they can chime in with some additional opinions. :smile:

# Open Questions & Closing Words
If this PR ends up being merged, I feel like this behavior should definitely be documented somewhere. However, I don't know where this documentation should live. If you point me towards your preferred location, I would be happy to write some docs regarding the behavior of the project root discovery. (In fact, I think the _current_ behavior of the project root algorithm should be documented somewhere as well — maybe it already is and I just haven't found it.)

Overall, if you don't feel comfortable with this change or if it doesn't fit the philosophy of the project, please feel free to deny this PR. No hard feelings in that case.

Thank you for your work on TexLab, it has been a joy to use so far!
