### PR TITLE
Unload unreachable files automatically

### DIFF
--- a/src/db/discovery.rs
+++ b/src/db/discovery.rs
@@ -272,6 +272,7 @@ pub fn clean_unreachable(db: &mut dyn Db, workspace: Workspace) {
         if reachable.contains(document) {
             true
         } else {
+            document.set_text(db).to(String::new());
             let uri = document.location(db).uri(db);
             log::debug!("Cleaning up unreachable document: {uri}");
             false

--- a/src/db/discovery.rs
+++ b/src/db/discovery.rs
@@ -217,6 +217,7 @@ fn discover_parents(db: &mut dyn Db, workspace: Workspace) -> bool {
     let dirs: FxHashSet<_> = workspace
         .documents(db)
         .iter()
+        .filter(|&&child| workspace.parents(db, child).is_empty())
         .flat_map(|document| document.ancestor_dirs(db))
         .filter(|path| is_part_of_workspace(db, workspace, path))
         .map(Path::to_path_buf)


### PR DESCRIPTION
- Unload unreachable files loaded by the server whenever the user closes a document
- Do not walk up the directory tree of a document if the root file is already known

See #856.