### PR TITLE
Implement build cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `texlab.cancelBuild` command to cancel the currently active build ([#887](https://github.com/latex-lsp/texlab/issues/887))
+
 ### Fixed
 
 - Fix resolving include commands from the `import` package ([#885](https://github.com/latex-lsp/texlab/issues/885))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "bstr",
  "crossbeam-channel",
  "itertools",
+ "libc",
  "log",
  "rowan",
  "rustc-hash",
@@ -872,9 +873,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linked-hash-map"

--- a/crates/commands/Cargo.toml
+++ b/crates/commands/Cargo.toml
@@ -12,6 +12,7 @@ base-db = { path = "../base-db" }
 bstr = "1.4.0"
 crossbeam-channel = "0.5.8"
 itertools = "0.10.5"
+libc = "0.2.144"
 log = "0.4.17"
 rowan = "0.15.11"
 rustc-hash = "1.1.0"


### PR DESCRIPTION
- Add `texlab.cancelBuild` workspace command to cancel all currently active builds. 
- Cancelled builds now return the previously unused `CANCELLED` status.
- Fixes #887.