### PR TITLE
Add support for `tectonic -X build`

### DIFF
--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use parser::SyntaxConfig;
@@ -22,7 +23,7 @@ pub struct BuildConfig {
     pub on_save: bool,
     pub forward_search_after: bool,
     pub output_dir: String,
-    pub output_filename: Option<String>,
+    pub output_filename: Option<PathBuf>,
 }
 
 #[derive(Debug)]

--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -22,6 +22,7 @@ pub struct BuildConfig {
     pub on_save: bool,
     pub forward_search_after: bool,
     pub output_dir: String,
+    pub output_filename: Option<String>,
 }
 
 #[derive(Debug)]
@@ -111,6 +112,7 @@ impl Default for BuildConfig {
             on_save: false,
             forward_search_after: false,
             output_dir: String::from("."),
+            output_filename: None,
         }
     }
 }

--- a/crates/base-db/src/workspace.rs
+++ b/crates/base-db/src/workspace.rs
@@ -144,6 +144,11 @@ impl Workspace {
         base_dir.join(&path).unwrap_or_else(|_| base_dir.clone())
     }
 
+    pub fn output_filename(&self) -> Option<PathBuf> {
+        let filename = self.config.build.output_filename.clone().map(PathBuf::from);
+        return filename;
+    }
+
     pub fn contains(&self, path: &Path) -> bool {
         if self.folders.is_empty() {
             return true;

--- a/crates/base-db/src/workspace.rs
+++ b/crates/base-db/src/workspace.rs
@@ -144,11 +144,6 @@ impl Workspace {
         base_dir.join(&path).unwrap_or_else(|_| base_dir.clone())
     }
 
-    pub fn output_filename(&self) -> Option<PathBuf> {
-        let filename = self.config.build.output_filename.clone().map(PathBuf::from);
-        return filename;
-    }
-
     pub fn contains(&self, path: &Path) -> bool {
         if self.folders.is_empty() {
             return true;

--- a/crates/commands/src/fwd_search.rs
+++ b/crates/commands/src/fwd_search.rs
@@ -65,10 +65,9 @@ impl ForwardSearch {
             return Err(ForwardSearchError::InvalidPath(child.uri.clone()));
         };
 
-        let override_path = workspace.output_filename();
+        let override_path = workspace.config().build.output_filename.as_deref();
 
-        let Some(pdf_path) = override_path.or(parent.path.clone())
-            .as_deref()
+        let Some(pdf_path) = override_path.or(parent.path.as_deref())
             .and_then(Path::file_stem)
             .and_then(OsStr::to_str)
             .map(|stem| dir.join(format!("{stem}.pdf"))) else 

--- a/crates/commands/src/fwd_search.rs
+++ b/crates/commands/src/fwd_search.rs
@@ -65,7 +65,9 @@ impl ForwardSearch {
             return Err(ForwardSearchError::InvalidPath(child.uri.clone()));
         };
 
-        let Some(pdf_path) = parent.path
+        let override_path = workspace.output_filename();
+
+        let Some(pdf_path) = override_path.or(parent.path.clone())
             .as_deref()
             .and_then(Path::file_stem)
             .and_then(OsStr::to_str)

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use base_db::{Config, Formatter, SynctexConfig};
@@ -155,7 +156,7 @@ impl From<Options> for Config {
         config.build.on_save = value.build.on_save;
         config.build.forward_search_after = value.build.forward_search_after;
         config.build.output_dir = value.aux_directory.unwrap_or_else(|| String::from("."));
-        config.build.output_filename = value.build.filename;
+        config.build.output_filename = value.build.filename.map(PathBuf::from);
 
         config.diagnostics.allowed_patterns = value
             .diagnostics

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -68,6 +68,7 @@ pub struct BuildOptions {
     pub args: Option<Vec<String>>,
     pub on_save: bool,
     pub forward_search_after: bool,
+    pub filename: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize)]
@@ -154,6 +155,7 @@ impl From<Options> for Config {
         config.build.on_save = value.build.on_save;
         config.build.forward_search_after = value.build.forward_search_after;
         config.build.output_dir = value.aux_directory.unwrap_or_else(|| String::from("."));
+        config.build.output_filename = value.build.filename;
 
         config.diagnostics.allowed_patterns = value
             .diagnostics


### PR DESCRIPTION
When trying to setup texlab with tectonic's `-X build` functionality, I ran into an issue where forward sync was not able to find the output pdf. This occurs because tectonic outputs to `$projectRoot/build/default/default.pdf`. This change adds a configuration option for `build.outputFilename` which will override the derived `pdf_path` if present.  This allows the for the following config (assuming Skim as the previewer)

```json
{
  "texlab.auxDirectory": "build/default/",
  "texlab.build.filename": "default.pdf",

  "texlab.build.executable": "tectonic",
  "texlab.build.args": [
    "-X",
    "build",
    "--keep-logs",
    "--keep-intermediates"
  ],
  "texlab.build.onSave": true,
  "texlab.build.forwardSearchAfter": true,

  "texlab.forwardSearch.executable": "/Applications/Skim.app/Contents/SharedSupport/displayline",
  "texlab.forwardSearch.args": ["-g", "%l", "%p", "%f"]
}
