### PR TITLE
Fix search path for aux files when using \include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report diagnostics for unused BibTeX entries and undefined citations
 - Report diagnostics for duplicate BibTeX entries
 - Report diagnostics for duplicate labels
+- Add `texlab.build.auxDirectory` and `texlab.build.logDirectory` settings ([#906](https://github.com/latex-lsp/texlab/issues/906))
+
+### Deprecated
+
+- Deprecate `texlab.auxDirectory` in favor of `texlab.build.auxDirectory`
 
 ### Fixed
 
 - Fix parsing paths with `|` ([#568](https://github.com/latex-lsp/texlab/issues/568))
 - Fix parsing LaTeX identifiers with `=` ([#568](https://github.com/latex-lsp/texlab/issues/568))
+- Fix search path for aux files when using `\include` instead of `\input` ([[#906](https://github.com/latex-lsp/texlab/issues/906))
 
 ## [5.7.0] - 2023-06-07
 

--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -22,7 +22,8 @@ pub struct BuildConfig {
     pub args: Vec<String>,
     pub on_save: bool,
     pub forward_search_after: bool,
-    pub output_dir: String,
+    pub aux_dir: String,
+    pub log_dir: String,
     pub output_filename: Option<PathBuf>,
 }
 
@@ -112,7 +113,8 @@ impl Default for BuildConfig {
                 .collect(),
             on_save: false,
             forward_search_after: false,
-            output_dir: String::from("."),
+            aux_dir: String::from("."),
+            log_dir: String::from("."),
             output_filename: None,
         }
     }

--- a/crates/base-db/src/data.rs
+++ b/crates/base-db/src/data.rs
@@ -25,13 +25,13 @@ pub struct BibtexFieldType<'a> {
 impl<'a> BibtexEntryType<'a> {
     pub fn find(name: &str) -> Option<Self> {
         BIBTEX_ENTRY_TYPES.iter().find(|ty| ty.name.eq_ignore_ascii_case(name)).copied()
-    }    
+    }
 }
 
 impl<'a> BibtexFieldType<'a> {
     pub fn find(name: &str) -> Option<Self> {
         BIBTEX_FIELD_TYPES.iter().find(|ty| ty.name.eq_ignore_ascii_case(name)).copied()
-    }    
+    }
 }
 
 

--- a/crates/commands/src/clean.rs
+++ b/crates/commands/src/clean.rs
@@ -22,7 +22,10 @@ impl CleanCommand {
         };
 
         let dir = workspace.current_dir(&document.dir);
-        let dir = workspace.output_dir(&dir).to_file_path().unwrap();
+        let dir = workspace
+            .output_dir(&dir, workspace.config().build.log_dir.clone())
+            .to_file_path()
+            .unwrap();
 
         let flag = match target {
             CleanTarget::Auxiliary => "-c",

--- a/crates/commands/src/fwd_search.rs
+++ b/crates/commands/src/fwd_search.rs
@@ -59,7 +59,10 @@ impl ForwardSearch {
         }
 
         let dir = workspace.current_dir(&parent.dir);
-        let dir = workspace.output_dir(&dir).to_file_path().unwrap();
+        let dir = workspace
+            .output_dir(&dir, workspace.config().build.log_dir.clone())
+            .to_file_path()
+            .unwrap();
 
         let Some(tex_path) = &child.path else {
             return Err(ForwardSearchError::InvalidPath(child.uri.clone()));
@@ -67,11 +70,12 @@ impl ForwardSearch {
 
         let override_path = workspace.config().build.output_filename.as_deref();
 
-        let Some(pdf_path) = override_path.or(parent.path.as_deref())
+        let Some(pdf_path) = override_path
+            .or(parent.path.as_deref())
             .and_then(Path::file_stem)
             .and_then(OsStr::to_str)
-            .map(|stem| dir.join(format!("{stem}.pdf"))) else 
-        {
+            .map(|stem| dir.join(format!("{stem}.pdf")))
+        else {
             return Err(ForwardSearchError::InvalidPath(parent.uri.clone()));
         };
 

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -69,6 +69,8 @@ pub struct BuildOptions {
     pub args: Option<Vec<String>>,
     pub on_save: bool,
     pub forward_search_after: bool,
+    pub aux_directory: Option<String>,
+    pub log_directory: Option<String>,
     pub filename: Option<String>,
 }
 
@@ -155,7 +157,19 @@ impl From<Options> for Config {
         config.build.args = value.build.args.unwrap_or(config.build.args);
         config.build.on_save = value.build.on_save;
         config.build.forward_search_after = value.build.forward_search_after;
-        config.build.output_dir = value.aux_directory.unwrap_or_else(|| String::from("."));
+
+        config.build.aux_dir = value
+            .build
+            .aux_directory
+            .or_else(|| value.aux_directory.clone())
+            .unwrap_or_else(|| String::from("."));
+
+        config.build.log_dir = value
+            .build
+            .log_directory
+            .or_else(|| value.aux_directory)
+            .unwrap_or_else(|| String::from("."));
+
         config.build.output_filename = value.build.filename.map(PathBuf::from);
 
         config.diagnostics.allowed_patterns = value


### PR DESCRIPTION
- Search in the same directory as well in addition to the configured `aux` directory
- Allow configuring `aux` directory independent of `log` directory
- Deprecate `texlab.auxDirectory` in favor of `texlab.build.auxDirectory`

Fixes #906.
