### PR TITLE
Allow passing additional arguments to ChkTeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Allow passing additional arguments to `ChkTeX` using `texlab.chktex.additionalArgs` ([#927](https://github.com/latex-lsp/texlab/issues/927))
+
 ## [5.9.2] - 2023-08-14
 
 ### Fixed

--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -41,6 +41,7 @@ pub struct ChktexConfig {
     pub on_open: bool,
     pub on_save: bool,
     pub on_edit: bool,
+    pub additional_args: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -139,6 +140,7 @@ impl Default for ChktexConfig {
             on_open: false,
             on_save: false,
             on_edit: false,
+            additional_args: Vec::new(),
         }
     }
 }

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -81,6 +81,7 @@ pub struct BuildOptions {
 pub struct ChktexOptions {
     pub on_open_and_save: bool,
     pub on_edit: bool,
+    pub additional_args: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize)]
@@ -199,6 +200,8 @@ impl From<Options> for Config {
         config.diagnostics.chktex.on_open = value.chktex.on_open_and_save;
         config.diagnostics.chktex.on_save = value.chktex.on_open_and_save;
         config.diagnostics.chktex.on_edit = value.chktex.on_edit;
+        config.diagnostics.chktex.additional_args =
+            value.chktex.additional_args.unwrap_or_default();
 
         config.formatting.tex_formatter = match value.latex_formatter {
             LatexFormatter::None => Formatter::Null,


### PR DESCRIPTION
Add `texlab.chktex.additionalArgs` setting.

Fixes #927.