### PR TITLE
Reliably determine latexmk's aux_dir and out_dir using -dir-report

### DIFF
--- a/crates/parser/src/latexmkrc.rs
+++ b/crates/parser/src/latexmkrc.rs
@@ -38,8 +38,7 @@ pub fn parse_latexmkrc(_input: &str) -> std::io::Result<LatexmkrcData> {
 ///   Latexmk: Normalized aux dir and out dir: '$aux_dir', '$out_dir'
 fn extract_dirs(line: &str) -> Option<(String, String)> {
     let mut it = line
-        .strip_prefix("Latexmk: Normalized aux dir and out dir: ")
-        .filter(|path| !path.is_empty())?
+        .strip_prefix("Latexmk: Normalized aux dir and out dir: ")?
         .split(", ");
 
     let aux_dir = it.next()?.strip_prefix('\'')?.strip_suffix('\'')?;


### PR DESCRIPTION
(Merging into feature branch of #968.)

This commit makes texlab determine aux_dir and out_dir variables by calling

```bash
latexmkrc -dir-report $TMPDIR/NONEXISTENT.tex
```

Passing NONEXISTENT file is a hack to prevent latexmk from building anything. And the $TMPDIR part should ensure 100% that this file does not exist (to avoid event rarest cases when user may have a file called NONEXISTENT.tex in current working directory).

This should be a more correct than `latexmk -r $TMPDIR/latexmkrc`, since `-dir-report` was intended exactly for this and it prints normalized values.