### PR TITLE
Fix potential crash when parsing build logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Do not report `undefined reference` errors when using `\nocite{*}` ([#964](https://github.com/latex-lsp/texlab/issues/964))
+- Fix potential crash when parsing build log files ([#973](https://github.com/latex-lsp/texlab/issues/973))
 
 ## [5.11.0] - 2023-11-05
 

--- a/crates/line-index/src/lib.rs
+++ b/crates/line-index/src/lib.rs
@@ -114,7 +114,7 @@ impl LineIndex {
     }
 
     pub fn offset(&self, line_col: LineCol) -> Option<TextSize> {
-        Some(self.newlines[line_col.line as usize] + TextSize::from(line_col.col))
+        Some(self.newlines.get(line_col.line as usize)? + TextSize::from(line_col.col))
     }
 
     pub fn to_utf16(&self, line_col: LineCol) -> Option<LineColUtf16> {


### PR DESCRIPTION
When encountering an error in the build log file, the server tries to convert the line number into a (zero)-based offset. If the line number is (for some reason) completely wrong, a panic in the server can occur.