### PR TITLE
Set final tab stop of \begin snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not report `undefined reference` errors when using `\nocite{*}` ([#964](https://github.com/latex-lsp/texlab/issues/964))
 - Fix potential crash when parsing build log files ([#973](https://github.com/latex-lsp/texlab/issues/973))
+- Set the final tab stop of the `\begin` snippet inside the environment ([#963](https://github.com/latex-lsp/texlab/issues/963))
 
 ## [5.11.0] - 2023-11-05
 

--- a/crates/texlab/src/features/completion.rs
+++ b/crates/texlab/src/features/completion.rs
@@ -169,7 +169,7 @@ impl<'a> ItemBuilder<'a> {
         if self.supports_snippets {
             result.kind = Some(Structure::Snippet.completion_kind());
             result.text_edit =
-                Some(lsp_types::TextEdit::new(range, "begin{$1}\n\t\n\\end{$1}".into()).into());
+                Some(lsp_types::TextEdit::new(range, "begin{$1}\n\t$0\n\\end{$1}".into()).into());
 
             result.insert_text_format = Some(lsp_types::InsertTextFormat::SNIPPET);
         } else {


### PR DESCRIPTION
Move the cursor inside the new environment after completing the `\begin` snippet.

Fixes #963.