### PR TITLE
Pre-expand bib string definitions and cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
 name = "citeproc"
 version = "0.0.0"
 dependencies = [
+ "base-db",
  "bibtex-utils",
  "expect-test",
  "isocountry",

--- a/crates/bibtex-utils/src/field.rs
+++ b/crates/bibtex-utils/src/field.rs
@@ -1,4 +1,9 @@
+use rustc_hash::FxHashMap;
+
 pub mod author;
 pub mod date;
 pub mod number;
 pub mod text;
+
+/// A cache used to accelerate related field parses.
+pub type FieldParseCache = FxHashMap<String, String>;

--- a/crates/bibtex-utils/src/field/author.rs
+++ b/crates/bibtex-utils/src/field/author.rs
@@ -4,7 +4,7 @@ use human_name::Name;
 use itertools::Itertools;
 use syntax::bibtex::Value;
 
-use super::text::TextFieldData;
+use super::{text::TextFieldData, FieldParseCache};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum AuthorField {
@@ -58,8 +58,8 @@ impl fmt::Display for AuthorFieldData {
 }
 
 impl AuthorFieldData {
-    pub fn parse(value: &Value) -> Option<Self> {
-        let TextFieldData { text } = TextFieldData::parse(value)?;
+    pub fn parse(value: &Value, cache: &FieldParseCache) -> Option<Self> {
+        let TextFieldData { text } = TextFieldData::parse(value, cache)?;
         let mut authors = Vec::new();
         let mut words = Vec::new();
         for word in text.split_whitespace() {

--- a/crates/bibtex-utils/src/field/date.rs
+++ b/crates/bibtex-utils/src/field/date.rs
@@ -3,7 +3,7 @@ use std::{fmt, ops::Add, str::FromStr};
 use chrono::{Datelike, Month, NaiveDate};
 use syntax::bibtex::Value;
 
-use super::text::TextFieldData;
+use super::{text::TextFieldData, FieldParseCache};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum DateField {
@@ -73,8 +73,8 @@ impl fmt::Display for DateFieldData {
 }
 
 impl DateFieldData {
-    pub fn parse(value: &Value) -> Option<Self> {
-        let TextFieldData { text } = TextFieldData::parse(value)?;
+    pub fn parse(value: &Value, cache: &FieldParseCache) -> Option<Self> {
+        let TextFieldData { text } = TextFieldData::parse(value, cache)?;
         NaiveDate::from_str(&text)
             .ok()
             .map(Self::Date)

--- a/crates/bibtex-utils/src/field/number.rs
+++ b/crates/bibtex-utils/src/field/number.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use syntax::bibtex::Value;
 
-use super::text::TextFieldData;
+use super::{text::TextFieldData, FieldParseCache};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum NumberField {
@@ -48,8 +48,8 @@ impl fmt::Display for NumberFieldData {
 }
 
 impl NumberFieldData {
-    pub fn parse(value: &Value) -> Option<Self> {
-        let TextFieldData { text } = TextFieldData::parse(value)?;
+    pub fn parse(value: &Value, cache: &FieldParseCache) -> Option<Self> {
+        let TextFieldData { text } = TextFieldData::parse(value, cache)?;
         text.split_once("--")
             .or_else(|| text.split_once('-'))
             .and_then(|(a, b)| Some((a.parse().ok()?, b.parse().ok()?)))

--- a/crates/citeproc/Cargo.toml
+++ b/crates/citeproc/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 bibtex-utils = { path = "../bibtex-utils" }
+base-db = { path = "../base-db" }
 isocountry = "0.3.2"
 itertools = "0.12.0"
 rowan = "0.15.15"

--- a/crates/citeproc/src/driver.rs
+++ b/crates/citeproc/src/driver.rs
@@ -1,3 +1,4 @@
+use base_db::semantics::bib::Semantics;
 use bibtex_utils::field::{
     author::AuthorField,
     date::DateField,
@@ -21,8 +22,8 @@ pub struct Driver {
 }
 
 impl Driver {
-    pub fn process(&mut self, entry: &bibtex::Entry) {
-        let entry = EntryData::from(entry);
+    pub fn process(&mut self, entry: &bibtex::Entry, semantics: &Semantics) {
+        let entry = EntryData::from_entry(entry, semantics);
         match entry.kind {
             EntryKind::Article
             | EntryKind::DataSet

--- a/crates/citeproc/src/lib.rs
+++ b/crates/citeproc/src/lib.rs
@@ -2,16 +2,17 @@ mod driver;
 mod entry;
 mod output;
 
+use base_db::semantics::bib::Semantics;
 use syntax::bibtex;
 use unicode_normalization::UnicodeNormalization;
 
 use self::{driver::Driver, output::Inline};
 
 #[must_use]
-pub fn render(entry: &bibtex::Entry) -> Option<String> {
+pub fn render(entry: &bibtex::Entry, semantics: &Semantics) -> Option<String> {
     let mut output = String::new();
     let mut driver = Driver::default();
-    driver.process(entry);
+    driver.process(entry, semantics);
     driver.finish().for_each(|(inline, punct)| {
         let text = match inline {
             Inline::Regular(text) => text,

--- a/crates/citeproc/src/tests.rs
+++ b/crates/citeproc/src/tests.rs
@@ -1,3 +1,4 @@
+use base_db::semantics::bib::Semantics;
 use expect_test::{expect, Expect};
 use parser::parse_bibtex;
 use rowan::ast::AstNode;
@@ -5,9 +6,12 @@ use syntax::bibtex;
 
 fn check(input: &str, expect: Expect) {
     let green = parse_bibtex(input);
-    let root = bibtex::Root::cast(bibtex::SyntaxNode::new_root(green)).unwrap();
+    let root = bibtex::SyntaxNode::new_root(green);
+    let mut semantics = Semantics::default();
+    semantics.process_root(&root);
+    let root = bibtex::Root::cast(root).unwrap();
     let entry = root.entries().next().unwrap();
-    let output = super::render(&entry).unwrap();
+    let output = super::render(&entry, &semantics).unwrap();
     expect.assert_eq(&output);
 }
 

--- a/crates/hover/src/citation.rs
+++ b/crates/hover/src/citation.rs
@@ -31,7 +31,7 @@ pub(super) fn find_hover<'a>(params: &HoverParams<'a>) -> Option<Hover<'a>> {
         let data = document.data.as_bib()?;
         let root = bibtex::Root::cast(data.root_node())?;
         let entry = root.find_entry(name)?;
-        citeproc::render(&entry)
+        citeproc::render(&entry, &data.semantics)
     })?;
 
     let data = HoverData::Citation(text);

--- a/crates/hover/src/string_ref.rs
+++ b/crates/hover/src/string_ref.rs
@@ -24,7 +24,7 @@ pub(super) fn find_hover<'a>(params: &HoverParams<'a>) -> Option<Hover<'a>> {
             continue;
         }
 
-        let value = TextFieldData::parse(&string.value()?)?.text;
+        let value = TextFieldData::parse(&string.value()?, &data.semantics.expanded_defs)?.text;
         return Some(Hover {
             range: name.text_range(),
             data: HoverData::StringRef(value),

--- a/crates/texlab/src/features/completion.rs
+++ b/crates/texlab/src/features/completion.rs
@@ -61,7 +61,7 @@ pub fn resolve(workspace: &Workspace, item: &mut lsp_types::CompletionItem) -> O
             let data = workspace.lookup(&uri)?.data.as_bib()?;
             let root = bibtex::Root::cast(data.root_node())?;
             let entry = root.find_entry(&key)?;
-            let value = citeproc::render(&entry)?;
+            let value = citeproc::render(&entry, &data.semantics)?;
             item.documentation = Some(lsp_types::Documentation::MarkupContent(
                 lsp_types::MarkupContent {
                     kind: lsp_types::MarkupKind::Markdown,


### PR DESCRIPTION
Hi there! Thank you for you work on this language server. I use it almost every day.

I've noticed that it struggles with large bib files. For example, I often use [cryptobib](https://github.com/cryptobib/export) (specifically, I use `abbrev3.bib` followed by `crypto.bib`) which has about 72k entries and about 8.7k string definitions. On this bib file, it takes texlab a few hundred seconds to just start up, which basically makes texlab unusable.

The slowdown appears to be an asymptotic inefficiency in how string references are resolved. This patch is one way to fix the problem, but no worries if you'd prefer a different approach: I'm happy to get feedback and modify the patch, or just hand it off to you.

Here is a small test script I wrote to measure the time it takes to read a bibfile. I ran it on a concatenation of `abbrev3.bib` and various prefixes of `crypto.bib`. For example, I've attached `abbrev3.bib` followed by 1000 entries from `crypto.bib`. Before this patch, the script below takes ~2s. With the patch, it takes ~18 milliseconds.

```rust
use base_db::semantics::bib::Semantics;
use parser::parse_bibtex;
use std::time::Instant;
use syntax::bibtex;

fn time_it<T>(label: &str, f: impl FnOnce() -> T) -> T {
    let start = Instant::now();
    let out = f();
    let time = start.elapsed();
    println!("{}: {:.3e}s", label, time.as_secs_f64());
    out
}

fn main() {
    let input = time_it("read", || {
        std::fs::read_to_string(std::env::args().nth(1).unwrap()).unwrap()
    });
    let green = time_it("parse", || parse_bibtex(&input));
    let semantics = time_it("semantics", || {
        let mut semantics = Semantics::default();
        semantics.process_root(&bibtex::SyntaxNode::new_root(green));
        semantics
    });
    println!("entries: {}", semantics.entries.len());
}
```

Cheers,
Alex


[1000.txt](https://github.com/latex-lsp/texlab/files/14554655/1000.txt)
