### PR TITLE
Fix clearing stale diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix clearing stale diagnostics reported by the server ([#1042](https://github.com/latex-lsp/texlab/issues/1042))
+
 ## [5.13.0] - 2024-03-10
 
 ### Added

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -34,14 +34,20 @@ impl Manager {
     }
 
     /// Returns all filtered diagnostics for the given workspace.
-    pub fn get(&self, workspace: &Workspace) -> MultiMap<Url, Diagnostic> {
-        let mut results = MultiMap::default();
+    pub fn get(&self, workspace: &Workspace) -> FxHashMap<Url, Vec<Diagnostic>> {
+        let mut results: FxHashMap<Url, Vec<Diagnostic>> = FxHashMap::default();
         for (uri, diagnostics) in &self.grammar {
-            results.insert_many_from_slice(uri.clone(), diagnostics);
+            results
+                .entry(uri.clone())
+                .or_default()
+                .extend(diagnostics.iter().cloned());
         }
 
         for (uri, diagnostics) in self.build_log.values().flatten() {
-            results.insert_many_from_slice(uri.clone(), diagnostics);
+            results
+                .entry(uri.clone())
+                .or_default()
+                .extend(diagnostics.iter().cloned());
         }
 
         for (uri, diagnostics) in &self.chktex {
@@ -49,7 +55,10 @@ impl Manager {
                 .lookup(uri)
                 .map_or(false, |document| document.owner == Owner::Client)
             {
-                results.insert_many_from_slice(uri.clone(), diagnostics);
+                results
+                    .entry(uri.clone())
+                    .or_default()
+                    .extend(diagnostics.iter().cloned());
             }
         }
 

--- a/crates/diagnostics/src/tests.rs
+++ b/crates/diagnostics/src/tests.rs
@@ -11,7 +11,7 @@ fn check(input: &str, expect: Expect) {
 
     let results = manager.get(&fixture.workspace);
     let results = results
-        .iter_all()
+        .iter()
         .filter(|(_, diags)| !diags.is_empty())
         .sorted_by(|(uri1, _), (uri2, _)| uri1.cmp(&uri2))
         .map(|(uri, diags)| (uri.as_str(), diags))


### PR DESCRIPTION
The `MultiMap::retain` function removes the entire entry if the associated `Vec` is empty. Switching to plain `HashMap` fixes the issue.

Fixes #1042.