### PR TITLE
Add snippets for \(, \[ and \{ delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve support for handling `Tectonic.toml` projects ([#1014](https://github.com/latex-lsp/texlab/issues/1014))
 - Cache results of project detection to improve performance
 - Triggering completion inside `\label{...}` will suggest undefined labels ([#1046](https://github.com/latex-lsp/texlab/issues/1046))
+- Add snippets for `\( ... \)`, `\[ ... \]` and `\{ ... \}` ([#1010](https://github.com/latex-lsp/texlab/issues/1010))
 
 ### Fixed
 

--- a/crates/completion/src/lib.rs
+++ b/crates/completion/src/lib.rs
@@ -45,6 +45,7 @@ impl<'a> CompletionItem<'a> {
 #[derive(Debug, PartialEq, Eq)]
 pub enum CompletionItemData<'a> {
     Command(CommandData<'a>),
+    CommandLikeDelimiter(&'a str, &'a str),
     BeginEnvironment,
     Citation(CitationData<'a>),
     Environment(EnvironmentData<'a>),
@@ -66,6 +67,7 @@ impl<'a> CompletionItemData<'a> {
     pub fn label<'b: 'a>(&'b self) -> &'a str {
         match self {
             Self::Command(data) => data.name,
+            Self::CommandLikeDelimiter(left, _) => left,
             Self::BeginEnvironment => "begin",
             Self::Citation(data) => &data.entry.name.text,
             Self::Environment(data) => data.name,
@@ -81,6 +83,30 @@ impl<'a> CompletionItemData<'a> {
             Self::EntryType(data) => data.0.name,
             Self::Field(data) => data.0.name,
             Self::TikzLibrary(name) => name,
+        }
+    }
+
+    /// Returns a number that can be used to sort the completion items further before resorting to the label.
+    /// This is useful for making snippets more visible.
+    pub fn sort_index(&self) -> u8 {
+        match self {
+            Self::Command(_) => 1,
+            Self::CommandLikeDelimiter(_, _) => 0,
+            Self::BeginEnvironment => 1,
+            Self::Citation(_) => 1,
+            Self::Environment(_) => 1,
+            Self::GlossaryEntry(_) => 1,
+            Self::Label(_) => 1,
+            Self::Color(_) => 1,
+            Self::ColorModel(_) => 1,
+            Self::File(_) => 1,
+            Self::Directory(_) => 1,
+            Self::Argument(_) => 1,
+            Self::Package(_) => 1,
+            Self::DocumentClass(_) => 1,
+            Self::EntryType(_) => 1,
+            Self::Field(_) => 1,
+            Self::TikzLibrary(_) => 1,
         }
     }
 }

--- a/crates/completion/src/tests.rs
+++ b/crates/completion/src/tests.rs
@@ -726,8 +726,20 @@ fn component_command_simple() {
 %! main.tex
 \
  |"#,
-        expect![[r##"
+        expect![[r#"
             [
+                CommandLikeDelimiter(
+                    "(",
+                    ")",
+                ),
+                CommandLikeDelimiter(
+                    "[",
+                    "]",
+                ),
+                CommandLikeDelimiter(
+                    "{",
+                    "\\}",
+                ),
                 Command(
                     CommandData {
                         name: "!",
@@ -740,26 +752,8 @@ fn component_command_simple() {
                         package: [],
                     },
                 ),
-                Command(
-                    CommandData {
-                        name: "#",
-                        package: [],
-                    },
-                ),
-                Command(
-                    CommandData {
-                        name: "$",
-                        package: [],
-                    },
-                ),
-                Command(
-                    CommandData {
-                        name: "%",
-                        package: [],
-                    },
-                ),
             ]
-        "##]],
+        "#]],
     );
 }
 

--- a/crates/completion/src/util/builder.rs
+++ b/crates/completion/src/util/builder.rs
@@ -32,6 +32,7 @@ impl<'a> CompletionBuilder<'a> {
             b.preselect
                 .cmp(&a.preselect)
                 .then_with(|| b.score.cmp(&a.score))
+                .then_with(|| a.data.sort_index().cmp(&b.data.sort_index()))
                 .then_with(|| a.data.label().cmp(b.data.label()))
         });
 


### PR DESCRIPTION
Add completion snippets for `\( ... \)`, `\[ ... \]` and `\{ ... \}` and adjust the sorting order so that they appear at the top of the list when typing `\`.

Closes #1010.