### PR TITLE
fix: avoid panic when drive path is empty

### DIFF
--- a/crates/texlab/src/util.rs
+++ b/crates/texlab/src/util.rs
@@ -22,7 +22,7 @@ pub fn normalize_uri(uri: &mut lsp_types::Url) {
 }
 
 fn fix_drive_letter(text: &str) -> Option<String> {
-    if !text.is_ascii() {
+    if !text.is_ascii() || text.len() == 0 {
         return None;
     }
 


### PR DESCRIPTION
I had texlab crash reproducibly lately when commenting/uncommenting lines within my neovim setup.

It turns out the root problem is an invalid array acces in a utility function.

I feel like the problem is that neovim is sendly weirdly formed events, but in any case, it is better to gracefully handle such problems rather than erroring out hard like the previous behavior.

This solved my problem.

I am not sure about how to add tests for such cases, but I can try to add one if needed, given guidance.
