### PR TITLE
Fix an aux_dir bug and support newer versions of latexmk

### DIFF
--- a/crates/base-db/src/deps/root.rs
+++ b/crates/base-db/src/deps/root.rs
@@ -93,7 +93,7 @@ impl ProjectRoot {
             .and_then(|path| append_dir(dir, path).ok())
             .unwrap_or_else(|| dir.clone());
 
-        let log_dir = out_dir.clone();
+        let log_dir = aux_dir.clone();
         let pdf_dir = out_dir;
         let additional_files = vec![];
 

--- a/crates/parser/src/latexmkrc.rs
+++ b/crates/parser/src/latexmkrc.rs
@@ -37,7 +37,15 @@ fn extract_dirs(lines: Lines) -> Option<(String, String)> {
         .split(",");
 
     let aux_dir = it.next()?.trim().strip_prefix('\'')?.strip_suffix('\'')?;
+
+    it.next(); // Skip the old 'outdir' option.
+
     let out_dir = it.next()?.trim().strip_prefix('\'')?.strip_suffix('\'')?;
+
+    // Ensure there's no more data
+    if it.next().is_some() {
+        return None;
+    }
 
     Some((String::from(aux_dir), String::from(out_dir)))
 }

--- a/crates/parser/src/latexmkrc.rs
+++ b/crates/parser/src/latexmkrc.rs
@@ -1,25 +1,17 @@
+use std::str::Lines;
+
 use syntax::latexmkrc::LatexmkrcData;
-use tempfile::tempdir;
 
 pub fn parse_latexmkrc(_input: &str) -> std::io::Result<LatexmkrcData> {
-    let temp_dir = tempdir()?;
-    let non_existent_tex = temp_dir.path().join("NONEXISTENT.tex");
 
-    // Run `latexmk -dir-report $TMPDIR/NONEXISTENT.tex` to obtain out_dir
-    // and aux_dir values. We pass nonexistent file to prevent latexmk from
-    // building anything, since we need this invocation only to extract the
-    // -dir-report variables.
-    //
-    // In the future, latexmk plans to implement -dir-report-only option and we
-    // won't have to resort to this hack with NONEXISTENT.tex.
+    // Run `latexmk -dir-report-only` to obtain out_dir and aux_dir values.
     let output = std::process::Command::new("latexmk")
-        .arg("-dir-report")
-        .arg(non_existent_tex)
+        .arg("-dir-report-only")
         .output()?;
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
-    let (aux_dir, out_dir) = stderr.lines().find_map(extract_dirs).ok_or_else(|| {
+    let (aux_dir, out_dir) =  extract_dirs(stdout.lines()).ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             "Normalized aux and out dir were not found in latexmk output",
@@ -34,19 +26,18 @@ pub fn parse_latexmkrc(_input: &str) -> std::io::Result<LatexmkrcData> {
 
 /// Extracts $aux_dir and $out_dir from lines of the form
 ///
-///   Latexmk: Normalized aux dir and out dir: '$aux_dir', '$out_dir'
-fn extract_dirs(line: &str) -> Option<(String, String)> {
-    let mut it = line
-        .strip_prefix("Latexmk: Normalized aux dir and out dir: ")?
-        .split(", ");
+///   Latexmk: Normalized aux dir and out dirs:
+///    '$aux_dir', '$out_dir', [...]
+fn extract_dirs(lines: Lines) -> Option<(String, String)> {
+    let mut it =
+        lines.skip_while(|line| {
+            !line.starts_with("Latexmk: Normalized aux dir and out dirs:")
+        })
+        .nth(1)?
+        .split(",");
 
-    let aux_dir = it.next()?.strip_prefix('\'')?.strip_suffix('\'')?;
-    let out_dir = it.next()?.strip_prefix('\'')?.strip_suffix('\'')?;
-
-    // Ensure there's no more data
-    if it.next().is_some() {
-        return None;
-    }
+    let aux_dir = it.next()?.trim().strip_prefix('\'')?.strip_suffix('\'')?;
+    let out_dir = it.next()?.trim().strip_prefix('\'')?.strip_suffix('\'')?;
 
     Some((String::from(aux_dir), String::from(out_dir)))
 }


### PR DESCRIPTION
First, 80d4334ead1116bea29725d7c097c75731bb215f is an independent fix for the fact `latexmk` outputs the log file to the `$aux_dir`, instead of the `$out_dir`. This would cause `texlab` to not report build errors in some projects, so it's probably related to https://github.com/latex-lsp/texlab/issues/836 (this is how I came to it).

Next, since[^1] `latexmk` v4.84 the current parsing mechanism of `texlab` for extracting the aux and out dirs stopped working, because the dirs are printed in a new line. I took the opportunity to use the new `-dir-report-only` option of `latexmk` and remove the code that was marked as a 'hack'. As v4.85 also uses a new out2dir option for a final output directory, I also included code to support it in the last commit 7bd2b11b79d84bf278784156048f60ad21cf4aca, but the man page describes it as "experimental" so I'm not sure if it's desired.

[^1]: https://www.cantab.net/users/johncollins/latexmk/versions.html