### PR TITLE
Support more macros for defining commands

### DIFF
--- a/crates/parser/src/latex/lexer/commands.rs
+++ b/crates/parser/src/latex/lexer/commands.rs
@@ -32,12 +32,10 @@ pub fn classify(name: &str, config: &SyntaxConfig) -> CommandName {
         "label" => CommandName::LabelDefinition,
         "crefrange" | "crefrange*" | "Crefrange" | "Crefrange*" => CommandName::LabelReferenceRange,
         "newlabel" => CommandName::LabelNumber,
-        "newcommand"
-        | "newcommand*"
-        | "renewcommand"
-        | "renewcommand*"
-        | "DeclareRobustCommand"
-        | "DeclareRobustCommand*" => CommandName::CommandDefinition,
+        "newcommand" | "newcommand*" | "renewcommand" | "renewcommand*"
+        | "DeclareRobustCommand" | "DeclareRobustCommand*"
+        | "NewDocumentCommand" | "RenewDocumentCommand" | "DeclareDocumentCommand"
+        | "NewCommandCopy" | "RenewCommandCopy" | "DeclareCommandCopy" => CommandName::CommandDefinition,
         "DeclareMathOperator" | "DeclareMathOperator*" => CommandName::MathOperator,
         "newglossaryentry" => CommandName::GlossaryEntryDefinition,
         "gls" | "Gls" | "GLS" | "glspl" | "Glspl" | "GLSpl" | "glsdisp" | "glslink" | "glstext"


### PR DESCRIPTION
Partially resolve #1081. _(doesn't implement handling of `\def`)_

Seems to work, but I am not sure whether there are other parts of the code that also need some changes.
