### PR TITLE
Remove unused root directory setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Remove unused `texlab.rootDirectory` setting
+
 ## [5.16.0] - 2024-05-01
 
 ### Added

--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -5,7 +5,6 @@ use regex::Regex;
 
 #[derive(Debug, Default)]
 pub struct Config {
-    pub root_dir: Option<String>,
     pub build: BuildConfig,
     pub diagnostics: DiagnosticsConfig,
     pub formatting: FormattingConfig,

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct Options {
-    pub root_directory: Option<String>,
     pub aux_directory: Option<String>,
     pub bibtex_formatter: BibtexFormatter,
     pub latex_formatter: LatexFormatter,

--- a/crates/texlab/src/util/from_proto.rs
+++ b/crates/texlab/src/util/from_proto.rs
@@ -361,7 +361,5 @@ pub fn config(value: Options) -> Config {
         .label_reference_commands
         .extend(value.experimental.label_reference_commands);
 
-    config.root_dir = value.root_directory;
-
     config
 }


### PR DESCRIPTION
`texlab.rootDirectory` does not have an effect anymore so it can be safely removed.