### PR TITLE
Fix parsing latexmkrc for latexmk < v4.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't treat `\label{}` and `\ref{}` with macro parameter as label commands ([#1119](https://github.com/latex-lsp/texlab/issues/1119))
+- Fix parsing `latexmkrc` for `latexmk` versions older than `v4.8.4` ([#1128](https://github.com/latex-lsp/texlab/issues/1128))
 
 ## [5.16.0] - 2024-05-01
 

--- a/crates/parser/src/latexmkrc.rs
+++ b/crates/parser/src/latexmkrc.rs
@@ -28,9 +28,9 @@ mod v483 {
             .current_dir(temp_dir.path())
             .output()?;
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
 
-        let (aux_dir, out_dir) = stderr.lines().find_map(extract_dirs).ok_or_else(|| {
+        let (aux_dir, out_dir) = stdout.lines().find_map(extract_dirs).ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "Normalized aux and out dir were not found in latexmk output",


### PR DESCRIPTION
Fixes #1128.