### PR TITLE
Handle URIs with lower case percent encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+<<<<<<< HEAD
 - Fix parsing commands with unicode characters inside BibTeX entries
   ([#1147](https://github.com/latex-lsp/texlab/issues/1147))
+=======
+- Improve detection of included files when non-ASCII characters are used ([#923](https://github.com/latex-lsp/texlab/issues/923))
+>>>>>>> 6aa43d5c (Handle URIs with lower case percent encoding)
 
 ## [5.17.0] - 2024-06-23
 


### PR DESCRIPTION
Improves detection of included files when non-ASCII characters are used by normalizing the casing of the percent encoding found in URIs.

See #923.