### PR TITLE
Use LaTeX file list in project detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Parse `.fls` files to make the project detection more reliable ([#1145](https://github.com/latex-lsp/texlab/issues/1145))
+
 ### Fixed
 
 - Fix parsing commands with unicode characters inside BibTeX entries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,6 +1532,7 @@ version = "0.0.0"
 dependencies = [
  "itertools 0.13.0",
  "rowan",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/base-db/src/document.rs
+++ b/crates/base-db/src/document.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use distro::Language;
 use line_index::{LineCol, LineIndex};
 use rowan::TextRange;
-use syntax::{bibtex, latex, latexmkrc::LatexmkrcData, BuildError};
+use syntax::{bibtex, file_list::FileList, latex, latexmkrc::LatexmkrcData, BuildError};
 use url::Url;
 
 use crate::{semantics, Config};
@@ -89,6 +89,7 @@ impl Document {
                 DocumentData::Latexmkrc(data)
             }
             Language::Tectonic => DocumentData::Tectonic,
+            Language::FileList => DocumentData::FileList(parser::parse_file_list(&text)),
         };
 
         Self {
@@ -146,6 +147,7 @@ pub enum DocumentData {
     Root,
     Latexmkrc(LatexmkrcData),
     Tectonic,
+    FileList(FileList),
 }
 
 impl DocumentData {
@@ -183,6 +185,14 @@ impl DocumentData {
 
     pub fn as_latexmkrc(&self) -> Option<&LatexmkrcData> {
         if let DocumentData::Latexmkrc(data) = self {
+            Some(data)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_file_list(&self) -> Option<&FileList> {
+        if let DocumentData::FileList(data) = self {
             Some(data)
         } else {
             None

--- a/crates/commands/src/dep_graph.rs
+++ b/crates/commands/src/dep_graph.rs
@@ -48,6 +48,7 @@ pub fn show_dependency_graph(workspace: &Workspace) -> Result<String> {
             base_db::deps::EdgeData::DirectLink(data) => &data.link.path.text,
             base_db::deps::EdgeData::AdditionalFiles => "<project>",
             base_db::deps::EdgeData::Artifact => "<artifact>",
+            base_db::deps::EdgeData::FileList(_) => "<fls>",
         };
 
         writeln!(&mut writer, "\t{source} -> {target} [label=\"{label}\"];")?;

--- a/crates/distro/src/language.rs
+++ b/crates/distro/src/language.rs
@@ -9,6 +9,7 @@ pub enum Language {
     Root,
     Latexmkrc,
     Tectonic,
+    FileList,
 }
 
 impl Language {
@@ -32,6 +33,7 @@ impl Language {
             "bib" | "bibtex" => Some(Self::Bib),
             "aux" => Some(Self::Aux),
             "log" => Some(Self::Log),
+            "fls" => Some(Self::FileList),
             _ => None,
         }
     }

--- a/crates/parser/src/file_list.rs
+++ b/crates/parser/src/file_list.rs
@@ -1,0 +1,44 @@
+use syntax::file_list::FileList;
+
+pub fn parse_file_list(input: &str) -> FileList {
+    let mut file_list = FileList::default();
+    for line in input.lines() {
+        if let Some(working_dir) = line.strip_prefix("PWD ") {
+            file_list.working_dir = Some(working_dir.into());
+        } else if let Some(input) = line.strip_prefix("INPUT ") {
+            file_list.inputs.insert(input.into());
+        } else if let Some(output) = line.strip_prefix("OUTPUT ") {
+            file_list.outputs.insert(output.into());
+        }
+    }
+
+    file_list
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashSet;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_file_list() {
+        let input = r#"
+PWD /home/user
+INPUT file1.tex
+INPUT file1.tex
+OUTPUT file2.pdf"#;
+
+        let expected_file_list = FileList {
+            working_dir: Some("/home/user".into()),
+            inputs: FxHashSet::from_iter(["file1.tex".into()]),
+            outputs: FxHashSet::from_iter(["file2.pdf".into()]),
+        };
+        let actual_file_list = parse_file_list(input);
+        assert_eq!(actual_file_list, expected_file_list);
+
+        assert_eq!(actual_file_list.working_dir, Some("/home/user".into()));
+        assert_eq!(actual_file_list.inputs.len(), 1);
+        assert_eq!(actual_file_list.outputs.len(), 1);
+    }
+}

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,11 +1,12 @@
 mod bibtex;
 mod build_log;
 mod config;
+mod file_list;
 mod latex;
 mod latexmkrc;
 pub(crate) mod util;
 
 pub use self::{
-    bibtex::parse_bibtex, build_log::parse_build_log, config::*, latex::parse_latex,
-    latexmkrc::parse_latexmkrc,
+    bibtex::parse_bibtex, build_log::parse_build_log, config::*, file_list::parse_file_list,
+    latex::parse_latex, latexmkrc::parse_latexmkrc,
 };

--- a/crates/symbols/src/document.rs
+++ b/crates/symbols/src/document.rs
@@ -23,6 +23,7 @@ pub fn document_symbols(workspace: &Workspace, document: &Document) -> Vec<Symbo
         | DocumentData::Log(_)
         | DocumentData::Root
         | DocumentData::Latexmkrc(_)
+        | DocumentData::FileList(_)
         | DocumentData::Tectonic => Vec::new(),
     };
 

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 itertools = "0.13.0"
 rowan = "0.15.15"
+rustc-hash = "1.1.0"
 
 [lib]
 doctest = false

--- a/crates/syntax/src/file_list.rs
+++ b/crates/syntax/src/file_list.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+use rustc_hash::FxHashSet;
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct FileList {
+    pub working_dir: Option<PathBuf>,
+    pub inputs: FxHashSet<PathBuf>,
+    pub outputs: FxHashSet<PathBuf>,
+}

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bibtex;
+pub mod file_list;
 pub mod latex;
 pub mod latexmkrc;
 

--- a/crates/texlab/src/features/formatting.rs
+++ b/crates/texlab/src/features/formatting.rs
@@ -27,6 +27,7 @@ pub fn format_source_code(
         | Language::Log
         | Language::Root
         | Language::Latexmkrc
-        | Language::Tectonic => None,
+        | Language::Tectonic
+        | Language::FileList => None,
     }
 }


### PR DESCRIPTION
Adds a parser for the `.fls` file that lists the working directory and all files processed during compilation. This can aid as a fallback when the regular syntax-based project detection fails due to macro definitions.

Fixes #1145.