### PR TITLE
Turn off .fls project detection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `texlab.build.useFileList` setting to allow controlling whether to use the `.fls` files
+
+### Changed
+
+- Disable using `.fls` files for project detection by default
+
 ## [5.18.0] - 2024-07-06
 
 ### Added

--- a/crates/base-db/src/deps/graph.rs
+++ b/crates/base-db/src/deps/graph.rs
@@ -103,7 +103,10 @@ impl Graph {
         self.add_direct_links(workspace, start);
         self.add_artifacts(workspace, start);
         self.add_additional_files(workspace, start);
-        self.add_file_list_links(workspace, start);
+
+        if workspace.config().syntax.use_file_list {
+            self.add_file_list_links(workspace, start);
+        }
     }
 
     fn add_additional_files(&mut self, workspace: &Workspace, start: Start) {

--- a/crates/parser/src/config.rs
+++ b/crates/parser/src/config.rs
@@ -3,6 +3,7 @@ use rustc_hash::FxHashSet;
 #[derive(Debug)]
 pub struct SyntaxConfig {
     pub follow_package_links: bool,
+    pub use_file_list: bool,
     pub math_environments: FxHashSet<String>,
     pub enum_environments: FxHashSet<String>,
     pub verbatim_environments: FxHashSet<String>,
@@ -57,6 +58,7 @@ impl Default for SyntaxConfig {
 
         Self {
             follow_package_links: false,
+            use_file_list: false,
             math_environments,
             enum_environments,
             verbatim_environments,

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -70,6 +70,7 @@ pub struct BuildOptions {
     pub log_directory: Option<String>,
     pub pdf_directory: Option<String>,
     pub filename: Option<String>,
+    pub use_file_list: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
Add `texlab.build.useFileList` setting to re-enable it.