### PR TITLE
Allow limiting inlay hint text length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `texlab.inlayHints.maxLength` setting to allow limiting inlay hint text length ([#1212](https://github.com/latex-lsp/texlab/issues/1212))
+
 ### Fixed
 
 - Fix enabling `texlab.build.useFileList` setting

--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -80,6 +80,7 @@ pub struct SymbolConfig {
 pub struct InlayHintConfig {
     pub label_definitions: bool,
     pub label_references: bool,
+    pub max_length: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -140,6 +141,7 @@ impl Default for InlayHintConfig {
         Self {
             label_definitions: true,
             label_references: true,
+            max_length: None,
         }
     }
 }

--- a/crates/texlab/src/features/inlay_hint.rs
+++ b/crates/texlab/src/features/inlay_hint.rs
@@ -7,10 +7,11 @@ pub fn find_all(
     params: lsp_types::InlayHintParams,
 ) -> Option<Vec<lsp_types::InlayHint>> {
     let params = from_proto::inlay_hint_params(workspace, params)?;
+    let line_index = &params.feature.document.line_index;
+    let max_length = workspace.config().inlay_hints.max_length;
     let hints = inlay_hints::find_all(&params)?
         .into_iter()
-        .filter_map(|hint| to_proto::inlay_hint(hint, &params.feature.document.line_index))
-        .collect();
+        .filter_map(|hint| to_proto::inlay_hint(hint, line_index, max_length));
 
-    Some(hints)
+    Some(hints.collect())
 }

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -104,6 +104,7 @@ pub struct DiagnosticsOptions {
 pub struct InlayHintOptions {
     pub label_definitions: Option<bool>,
     pub label_references: Option<bool>,
+    pub max_length: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/texlab/src/util/from_proto.rs
+++ b/crates/texlab/src/util/from_proto.rs
@@ -305,6 +305,7 @@ pub fn config(value: Options) -> Config {
 
     config.inlay_hints.label_definitions = value.inlay_hints.label_definitions.unwrap_or(true);
     config.inlay_hints.label_references = value.inlay_hints.label_references.unwrap_or(true);
+    config.inlay_hints.max_length = value.inlay_hints.max_length;
 
     config.completion.matcher = match value.completion.matcher {
         CompletionMatcher::Fuzzy => base_db::MatchingAlgo::Skim,


### PR DESCRIPTION
Add `texlab.inlayHints.maxLength` setting.

Fixes #1212.