### PR TITLE
Enable aarch64-unknown-linux-gnu CI job

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,37 +12,58 @@ env:
   RUSTFLAGS: "-D warnings"
 jobs:
   build:
-    name: Build (${{ matrix.os }})
+    name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            test: true
+
+          - os: windows-latest
+            target: i686-pc-windows-msvc
+            test: true
+
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            test: true
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            test: true
+
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            install: sudo apt-get install -y gcc-aarch64-linux-gnu
+
+          - os: ubuntu-20.04
+            target: armv7-unknown-linux-gnueabihf
+            install: sudo apt-get install -y gcc-arm-linux-gnueabihf
+
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+      - name: Install cross-compilation dependencies
+        run: ${{ matrix.install }}
+        if: ${{ matrix.install }}
       - name: Compile
-        run: cargo test --all-features --no-run --locked
+        run: cargo test --target ${{ matrix.target }} --all-features --no-run --locked
       - name: Test
-        run: cargo test --all-features -- --nocapture --quiet
-  build_cross:
-    name: Build (${{ matrix.target }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          # TODO: Re-add once the GitHub environment is fixed
-          # - aarch64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo install cross
-      - name: Compile
-        run: cross build --target ${{ matrix.target }}
+        run: cargo test --target ${{ matrix.target }} --all-features -- --nocapture --quiet
+        if: ${{ matrix.test }}
   msrv:
     name: MSRV
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,58 +16,51 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            program: cargo
             archive: texlab-x86_64-windows.zip
 
           - os: windows-latest
             target: i686-pc-windows-msvc
-            program: cargo
             archive: texlab-i686-windows.zip
 
           - os: windows-latest
             target: aarch64-pc-windows-msvc
-            program: cargo
             archive: texlab-aarch64-windows.zip
 
           - os: macos-latest
             target: x86_64-apple-darwin
-            program: cargo
             archive: texlab-x86_64-macos.tar.gz
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            program: cargo
             archive: texlab-aarch64-macos.tar.gz
 
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-            program: cargo
             archive: texlab-x86_64-linux.tar.gz
 
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
-            program: cross
             archive: texlab-aarch64-linux.tar.gz
+            install: sudo apt-get install -y gcc-aarch64-linux-gnu
 
           - os: ubuntu-20.04
             target: armv7-unknown-linux-gnueabihf
-            program: cross
             archive: texlab-armv7hf-linux.tar.gz
+            install: sudo apt-get install -y gcc-arm-linux-gnueabihf
 
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-musl
-            program: cargo
             archive: texlab-x86_64-alpine.tar.gz
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install cross
-        if: ${{ matrix.program == 'cross' }}
-        run: cargo install cross
+      - name: Install cross-compilation dependencies
+        run: ${{ matrix.install }}
+        if: ${{ matrix.install }}
       - name: Compile
-        run: ${{ matrix.program }} build --target ${{ matrix.target }} --all-features --release --locked
+        run: cargo build --target ${{ matrix.target }} --all-features --release --locked
       - name: Compress (Windows)
         if: ${{ contains(matrix.os, 'windows') }}
         run: ${{ format('Compress-Archive target/{0}/release/texlab.exe {1}', matrix.target, matrix.archive) }}
@@ -105,7 +98,7 @@ jobs:
       - name: Install Tectonic workaround
         run: |
           sudo add-apt-repository universe
-          sudo apt install libfuse2 libssl3
+          sudo apt-get install libfuse2 libssl3
       - name: Install Tectonic
         uses: wtfjoke/setup-tectonic@v3
         with:
@@ -116,7 +109,7 @@ jobs:
           tectonic texlab.tex -o texlab
       - name: Generate man page
         run: |
-          sudo apt install -y help2man
+          sudo apt-get install -y help2man
           cargo build
           help2man --output=texlab/texlab.1 --no-info "target/debug/texlab"
       - name: Export to ZIP archive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fern"
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -681,6 +681,12 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "highlights"
@@ -781,13 +787,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -884,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -994,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
@@ -1071,7 +1077,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -1372,9 +1378,9 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.4.0",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
     "Patrick Förster <patrick.foerster@outlook.de>",
 ]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [workspace.dependencies]
 anyhow = "1.0.87"


### PR DESCRIPTION
Use `cargo build --target <...>` directly instead of `cross` to work around issue with `aarch64-unknown-linux-gnu` target.