### PR TITLE
add latexindent replacement options

### DIFF
--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -68,6 +68,7 @@ pub enum Formatter {
 pub struct LatexIndentConfig {
     pub local: Option<String>,
     pub modify_line_breaks: bool,
+    pub replacement: Option<String>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/texlab/src/features/formatting/latexindent.rs
+++ b/crates/texlab/src/features/formatting/latexindent.rs
@@ -72,6 +72,15 @@ fn build_arguments(config: &LatexIndentConfig, target_file: &Path) -> Vec<String
         args.push("--modifylinebreaks".to_string());
     }
 
+    match &config.replacement {
+        Some(replacement_flag) => {
+            if ["-r", "-rv", "-rr"].contains(& replacement_flag.as_str()) {
+                args.push(replacement_flag.clone());
+            }
+        },
+        None => {}
+    }
+
     args.push(target_file.display().to_string());
     args
 }

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -56,6 +56,7 @@ impl Default for LatexFormatter {
 pub struct LatexindentOptions {
     pub local: Option<String>,
     pub modify_line_breaks: bool,
+    pub replacement: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize)]

--- a/crates/texlab/src/util/from_proto.rs
+++ b/crates/texlab/src/util/from_proto.rs
@@ -282,6 +282,7 @@ pub fn config(value: Options) -> Config {
 
     config.formatting.latex_indent.local = value.latexindent.local;
     config.formatting.latex_indent.modify_line_breaks = value.latexindent.modify_line_breaks;
+    config.formatting.latex_indent.replacement = value.latexindent.replacement;
 
     config.synctex = value
         .forward_search


### PR DESCRIPTION
Resolves #1222 

I added an Option<String> field "replacement" to the LatexIndentConfig structs, and modified the build_arguments function to check if it config.replacement contains one of "-r", "-rr", or "-rv". If so, it appends that to the list of arguments to LatexIndent. If it does not exist, or it contains any other string, the option is ignored. 

Tested on
NVIM v0.11.0-dev-386+g545aafbeb
latexindent.pl version 3.24.4, 2024-07-18
macOS 11.7.10 (x86_64)