### PR TITLE
document symbols numbering as in toc

### DIFF
--- a/crates/base-db/src/semantics/auxiliary.rs
+++ b/crates/base-db/src/semantics/auxiliary.rs
@@ -48,20 +48,29 @@ impl Semantics {
     fn process_toc_line(&mut self, toc_line: &latex::TocContentsLine) -> Option<()> {
         let unit = toc_line.unit().and_then(|u| u.content_text())?.to_string();
 
-        if ["section", "subsection"].contains(&unit.as_str()) {
+        if [
+            "part",
+            "chapter",
+            "section",
+            "subsection",
+            "subsubsection",
+            "paragraph",
+            "subparagraph",
+        ]
+        .contains(&unit.as_str())
+        {
             let line = toc_line.line()?;
-            let name = line
-                .syntax()
-                .children()
-                .find_map(|child| { latex::Text::cast(child.clone())?; Some(child)})?;
+            let name = line.syntax().children().find_map(|child| {
+                latex::Text::cast(child.clone())?;
+                Some(child)
+            })?;
             let name = name.to_string();
 
             let num_line = line
                 .syntax()
                 .children()
                 .find_map(|child| latex::TocNumberLine::cast(child.clone()))?;
-            let number = num_line
-                .number()?;
+            let number = num_line.number()?;
             let number = number.content_text()?.replace(['{', '}'], "");
             self.section_numbers.insert(name, number);
         }

--- a/crates/base-db/src/semantics/auxiliary.rs
+++ b/crates/base-db/src/semantics/auxiliary.rs
@@ -5,6 +5,7 @@ use syntax::latex::{self, HasCurly};
 #[derive(Debug, Clone, Default)]
 pub struct Semantics {
     pub label_numbers: FxHashMap<String, String>,
+    pub section_numbers: FxHashMap<String, String>,
 }
 
 impl Semantics {
@@ -17,6 +18,9 @@ impl Semantics {
     fn process_node(&mut self, node: &latex::SyntaxNode) {
         if let Some(label_number) = latex::LabelNumber::cast(node.clone()) {
             self.process_label_number(&label_number);
+        }
+        if let Some(toc_line) = latex::TocContentsLine::cast(node.clone()) {
+            self.process_toc_line(&toc_line);
         }
     }
 
@@ -38,6 +42,29 @@ impl Semantics {
 
         let text = group.content_text()?.replace(['{', '}'], "");
         self.label_numbers.insert(name, text);
+        Some(())
+    }
+
+    fn process_toc_line(&mut self, toc_line: &latex::TocContentsLine) -> Option<()> {
+        let unit = toc_line.unit().and_then(|u| u.content_text())?.to_string();
+
+        if ["section", "subsection"].contains(&unit.as_str()) {
+            let line = toc_line.line()?;
+            let name = line
+                .syntax()
+                .children()
+                .find_map(|child| { latex::Text::cast(child.clone())?; Some(child)})?;
+            let name = name.to_string();
+
+            let num_line = line
+                .syntax()
+                .children()
+                .find_map(|child| latex::TocNumberLine::cast(child.clone()))?;
+            let number = num_line
+                .number()?;
+            let number = number.content_text()?.replace(['{', '}'], "");
+            self.section_numbers.insert(name, number);
+        }
         Some(())
     }
 }

--- a/crates/parser/src/latex.rs
+++ b/crates/parser/src/latex.rs
@@ -159,6 +159,8 @@ impl<'a> Parser<'a> {
                 CommandName::VerbatimBlock => self.verbatim_block(),
                 CommandName::GraphicsPath => self.graphics_path(),
                 CommandName::BibItem => self.bibitem(),
+                CommandName::TocContentsLine => self.toc_contents_line(),
+                CommandName::TocNumberLine => self.toc_number_line(),
             },
         }
     }
@@ -1257,6 +1259,38 @@ impl<'a> Parser<'a> {
 
         if self.lexer.peek() == Some(Token::LCurly) {
             self.curly_group_word();
+        }
+
+        self.builder.finish_node();
+    }
+
+    fn toc_contents_line(&mut self) {
+        self.builder.start_node(TOC_CONTENTS_LINE.into());
+        self.eat();
+        self.trivia();
+
+        if self.lexer.peek() == Some(Token::LCurly) {
+            self.curly_group();
+        }
+
+        if self.lexer.peek() == Some(Token::LCurly) {
+            self.curly_group();
+        }
+
+        if self.lexer.peek() == Some(Token::LCurly) {
+            self.curly_group();
+        }
+
+        self.builder.finish_node();
+    }
+
+    fn toc_number_line(&mut self) {
+        self.builder.start_node(TOC_NUMBER_LINE.into());
+        self.eat();
+        self.trivia();
+
+        if self.lexer.peek() == Some(Token::LCurly) {
+            self.curly_group();
         }
 
         self.builder.finish_node();

--- a/crates/parser/src/latex/lexer/commands.rs
+++ b/crates/parser/src/latex/lexer/commands.rs
@@ -97,6 +97,8 @@ pub fn classify(name: &str, config: &SyntaxConfig) -> CommandName {
         "fi" => CommandName::EndBlockComment,
         "verb" => CommandName::VerbatimBlock,
         "bibitem" => CommandName::BibItem,
+        "contentsline" => CommandName::TocContentsLine,
+        "numberline" => CommandName::TocNumberLine,
 
         _ if config.citation_commands.contains(name) => CommandName::Citation,
         _ if config.label_definition_commands.contains(name) => CommandName::LabelDefinition,

--- a/crates/parser/src/latex/lexer/types.rs
+++ b/crates/parser/src/latex/lexer/types.rs
@@ -96,6 +96,8 @@ pub enum CommandName {
     EndBlockComment,
     VerbatimBlock,
     BibItem,
+    TocContentsLine,
+    TocNumberLine,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]

--- a/crates/symbols/src/document/tests.rs
+++ b/crates/symbols/src/document/tests.rs
@@ -281,44 +281,44 @@ fn test_section() {
     check(
         &fixture,
         expect![[r#"
-        [
-            Symbol {
-                name: "Foo",
-                kind: Section,
-                label: None,
-                full_range: 43..56,
-                selection_range: 43..56,
-                children: [],
-            },
-            Symbol {
-                name: "2 Bar",
-                kind: Section,
-                label: Some(
-                    Span(
-                        "sec:bar",
-                        71..86,
-                    ),
-                ),
-                full_range: 58..119,
-                selection_range: 71..86,
-                children: [
-                    Symbol {
-                        name: "Baz",
-                        kind: Section,
-                        label: Some(
-                            Span(
-                                "sec:baz",
-                                104..119,
-                            ),
+            [
+                Symbol {
+                    name: "1 Foo",
+                    kind: Section,
+                    label: None,
+                    full_range: 43..56,
+                    selection_range: 43..56,
+                    children: [],
+                },
+                Symbol {
+                    name: "2 Bar",
+                    kind: Section,
+                    label: Some(
+                        Span(
+                            "sec:bar",
+                            71..86,
                         ),
-                        full_range: 88..119,
-                        selection_range: 104..119,
-                        children: [],
-                    },
-                ],
-            },
-        ]
-    "#]],
+                    ),
+                    full_range: 58..119,
+                    selection_range: 71..86,
+                    children: [
+                        Symbol {
+                            name: "Baz",
+                            kind: Section,
+                            label: Some(
+                                Span(
+                                    "sec:baz",
+                                    104..119,
+                                ),
+                            ),
+                            full_range: 88..119,
+                            selection_range: 104..119,
+                            children: [],
+                        },
+                    ],
+                },
+            ]
+        "#]],
     );
 }
 

--- a/crates/syntax/src/latex/cst.rs
+++ b/crates/syntax/src/latex/cst.rs
@@ -762,3 +762,31 @@ impl BibItem {
         self.syntax().children().find_map(CurlyGroupWord::cast)
     }
 }
+
+cst_node!(TocContentsLine, TOC_CONTENTS_LINE);
+
+impl TocContentsLine {
+    pub fn command(&self) -> Option<SyntaxToken> {
+        self.syntax().first_token()
+    }
+
+    pub fn unit(&self) -> Option<CurlyGroup> {
+        self.syntax().children().find_map(CurlyGroup::cast)
+    }
+
+    pub fn line(&self) -> Option<CurlyGroup> {
+        self.syntax().children().filter_map(CurlyGroup::cast).nth(1)
+    }
+}
+
+cst_node!(TocNumberLine, TOC_NUMBER_LINE);
+
+impl TocNumberLine {
+    pub fn command(&self) -> Option<SyntaxToken> {
+        self.syntax().first_token()
+    }
+
+    pub fn number(&self) -> Option<CurlyGroup> {
+        self.syntax().children().find_map(CurlyGroup::cast)
+    }
+}

--- a/crates/syntax/src/latex/kind.rs
+++ b/crates/syntax/src/latex/kind.rs
@@ -83,6 +83,8 @@ pub enum SyntaxKind {
     GRAPHICS_PATH,
     BLOCK_COMMENT,
     BIBITEM,
+    TOC_CONTENTS_LINE,
+    TOC_NUMBER_LINE,
     ROOT,
 }
 


### PR DESCRIPTION
Fix #910 
Created new command variants for \contentline and \numberline, and added section_numbers to aux doc data struct.
Now, uses the numbering from the table of contents to number sections in the documents symbols list.
This PR changes the expected output of the document symbol unit test, so the test is updated as well.

```
\documentclass{article}

\begin{document}

\section{First Section}\label{asec:outer} % 1 Section
	\begin{equation}\label{eq:myEQ}
		1 + 1 = 2
	\end{equation}

	\subsection{Subsection}{First Subsection} % 1.1 Subsection

\section{Another Section} % 2 Section'
	\subsection{Dummy} % 2.1 Dummy
	\subsection*{Subsection'}\label{sec:inner} % Subsection'

\end{document}
```
produces the following document symbols
```
main.tex|5 col 24| [Module] 1 First Section
main.tex|6 col 18| [Constant] Equation (1)
main.tex|10 col 2| [Module] 1.1 Subsection
main.tex|12 col 1| [Module] 2 Another Section
main.tex|13 col 2| [Module] 2.1 Dummy
main.tex|14 col 27| [Module] Subsection'
```