### PR TITLE
Resolve paths that are part of TEXINPUTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support starred variants in "Go to References" ([#1234](https://github.com/latex-lsp/texlab/issues/1234))
+- Add `texlab.latexindent.replacement` setting to allow passing a replacement flag to `latexindent` ([#1222](https://github.com/latex-lsp/texlab/issues/1222))
+- Don't require a label to show section numbers for document symbols ([#910](https://github.com/latex-lsp/texlab/issues/910))
+
 ### Fixed
 
 - Fix opening `untitled` documents ([#1242](https://github.com/latex-lsp/texlab/issues/1242))
+- Handle `\bibitem` when checking for undefined references ([#1171](https://github.com/latex-lsp/texlab/issues/1171))
+- Fix false-positive syntax error when using a command inside a `\label` ([#879](https://github.com/latex-lsp/texlab/issues/879))
 
 ## [5.20.0] - 2024-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support starred variants in "Go to References" ([#1234](https://github.com/latex-lsp/texlab/issues/1234))
 - Add `texlab.latexindent.replacement` setting to allow passing a replacement flag to `latexindent` ([#1222](https://github.com/latex-lsp/texlab/issues/1222))
 - Don't require a label to show section numbers for document symbols ([#910](https://github.com/latex-lsp/texlab/issues/910))
+- Support navigating to files that are part of the `TEXINPUTS` similar to `BIBINPUTS` ([#1228](https://github.com/latex-lsp/texlab/discussions/1228))
 
 ### Fixed
 

--- a/crates/distro/src/lib.rs
+++ b/crates/distro/src/lib.rs
@@ -4,7 +4,10 @@ mod language;
 mod miktex;
 mod texlive;
 
-use std::process::{Command, Stdio};
+use std::{
+    env,
+    process::{Command, Stdio},
+};
 
 use anyhow::Result;
 
@@ -70,8 +73,14 @@ impl Distro {
             DistroKind::Tectonic | DistroKind::Unknown => FileNameDB::default(),
         };
 
-        if let Some(bibinputs) = std::env::var_os("BIBINPUTS") {
-            for dir in std::env::split_paths(&bibinputs) {
+        Self::read_env_dir(&mut file_name_db, "TEXINPUTS");
+        Self::read_env_dir(&mut file_name_db, "BIBINPUTS");
+        Ok(Self { kind, file_name_db })
+    }
+
+    fn read_env_dir(file_name_db: &mut FileNameDB, env_var: &str) {
+        if let Some(paths) = env::var_os(env_var) {
+            for dir in env::split_paths(&paths) {
                 if let Ok(entries) = std::fs::read_dir(dir) {
                     for file in entries
                         .flatten()
@@ -83,7 +92,5 @@ impl Distro {
                 }
             }
         }
-
-        Ok(Self { kind, file_name_db })
     }
 }


### PR DESCRIPTION
Add paths in `TEXINPUTS` to the distro resolver similar to the way it is done for `BIBINPUTS`.

Fixes https://github.com/latex-lsp/texlab/discussions/1228.