### PR TITLE
Diagnostic and Quickfix for `\usepackage` duplicates and ordering

### DIFF
--- a/crates/base-db/src/semantics/tex.rs
+++ b/crates/base-db/src/semantics/tex.rs
@@ -113,7 +113,14 @@ impl Semantics {
 
         for path in list.keys() {
             let kind = match include.syntax().kind() {
-                latex::PACKAGE_INCLUDE => LinkKind::Sty,
+                latex::PACKAGE_INCLUDE => {
+                    if path.to_string().contains(".sty") {
+                        LinkKind::Sty
+                    }
+                    else {
+                        LinkKind::Pkg
+                    }
+                }
                 latex::CLASS_INCLUDE => LinkKind::Cls,
                 latex::LATEX_INCLUDE => LinkKind::Tex,
                 latex::BIBLATEX_INCLUDE => LinkKind::Bib,
@@ -124,6 +131,7 @@ impl Semantics {
             self.links.push(Link {
                 kind,
                 path: Span::from(&path),
+                full_range: latex::small_range(&include),
                 base_dir: None,
             });
         }
@@ -147,11 +155,13 @@ impl Semantics {
         };
         let text = format!("{base_dir}{}", path.to_string());
         let range = latex::small_range(&path);
+        let full_range = latex::small_range(&import);
 
         self.links.push(Link {
             kind: LinkKind::Tex,
             path: Span { text, range },
             base_dir: Some(base_dir),
+            full_range,
         });
     }
 
@@ -364,6 +374,7 @@ impl Semantics {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum LinkKind {
+    Pkg,
     Sty,
     Cls,
     Tex,
@@ -373,6 +384,7 @@ pub enum LinkKind {
 impl LinkKind {
     pub fn extensions(self) -> &'static [&'static str] {
         match self {
+            Self::Pkg => &[""],
             Self::Sty => &["sty"],
             Self::Cls => &["cls"],
             Self::Tex => &["tex"],
@@ -386,11 +398,13 @@ pub struct Link {
     pub kind: LinkKind,
     pub path: Span,
     pub base_dir: Option<String>,
+    pub full_range: TextRange,
 }
 
 impl Link {
     pub fn package_name(&self) -> Option<String> {
         match self.kind {
+            LinkKind::Pkg => Some(self.path.text.clone()),
             LinkKind::Sty => Some(format!("{}.sty", self.path.text)),
             LinkKind::Cls => Some(format!("{}.cls", self.path.text)),
             _ => None,

--- a/crates/base-db/src/semantics/tex.rs
+++ b/crates/base-db/src/semantics/tex.rs
@@ -113,14 +113,7 @@ impl Semantics {
 
         for path in list.keys() {
             let kind = match include.syntax().kind() {
-                latex::PACKAGE_INCLUDE => {
-                    if path.to_string().contains(".sty") {
-                        LinkKind::Sty
-                    }
-                    else {
-                        LinkKind::Pkg
-                    }
-                }
+                latex::PACKAGE_INCLUDE => LinkKind::Sty,
                 latex::CLASS_INCLUDE => LinkKind::Cls,
                 latex::LATEX_INCLUDE => LinkKind::Tex,
                 latex::BIBLATEX_INCLUDE => LinkKind::Bib,
@@ -374,7 +367,6 @@ impl Semantics {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum LinkKind {
-    Pkg,
     Sty,
     Cls,
     Tex,
@@ -384,7 +376,6 @@ pub enum LinkKind {
 impl LinkKind {
     pub fn extensions(self) -> &'static [&'static str] {
         match self {
-            Self::Pkg => &[""],
             Self::Sty => &["sty"],
             Self::Cls => &["cls"],
             Self::Tex => &["tex"],
@@ -404,7 +395,6 @@ pub struct Link {
 impl Link {
     pub fn package_name(&self) -> Option<String> {
         match self.kind {
-            LinkKind::Pkg => Some(self.path.text.clone()),
             LinkKind::Sty => Some(format!("{}.sty", self.path.text)),
             LinkKind::Cls => Some(format!("{}.cls", self.path.text)),
             _ => None,

--- a/crates/base-db/src/util/queries.rs
+++ b/crates/base-db/src/util/queries.rs
@@ -217,7 +217,6 @@ impl<'a> Conflict<'a> {
 
         let mut conflicts = Vec::new();
         for group in groups.into_values().filter(|group| group.len() > 1) {
-            log::debug!("group: {:?}", group);
             for (i, main) in group
                 .iter()
                 .enumerate()

--- a/crates/base-db/src/util/queries.rs
+++ b/crates/base-db/src/util/queries.rs
@@ -44,6 +44,33 @@ pub trait Object {
     }
 }
 
+impl Object for tex::Link {
+    fn name_text(&self) -> &str {
+        &self.path.text
+    }
+
+    fn name_range(&self) -> TextRange {
+        self.path.range
+    }
+
+    fn full_range(&self) -> TextRange {
+        self.full_range
+    }
+
+    fn kind(&self) -> ObjectKind {
+        ObjectKind::Definition
+    }
+
+    fn find<'db>(document: &'db Document) -> Box<dyn Iterator<Item = &'db Self> + 'db> {
+        let data = document.data.as_tex();
+        let iter = data
+            .into_iter()
+            .flat_map(|data| data.semantics.links.iter());
+
+        Box::new(iter)
+    }
+}
+
 impl Object for tex::Label {
     fn name_text(&self) -> &str {
         &self.name.text
@@ -190,6 +217,7 @@ impl<'a> Conflict<'a> {
 
         let mut conflicts = Vec::new();
         for group in groups.into_values().filter(|group| group.len() > 1) {
+            log::debug!("group: {:?}", group);
             for (i, main) in group
                 .iter()
                 .enumerate()

--- a/crates/diagnostics/src/imports.rs
+++ b/crates/diagnostics/src/imports.rs
@@ -1,95 +1,14 @@
-use base_db::{semantics::tex::Link, util::queries, Document, Workspace};
-use itertools::Itertools;
+use base_db::{semantics::tex::Link, util::queries, Workspace};
 use rustc_hash::FxHashMap;
-use syntax::latex::{self, SyntaxKind};
 use url::Url;
 
 use crate::{types::Diagnostic, ImportError};
-
-pub(crate) fn update(
-    document: &Document,
-    _config: &base_db::Config,
-    _imports: &mut std::collections::HashMap<Url, Vec<Diagnostic>, rustc_hash::FxBuildHasher>,
-) -> Option<()> {
-    let root = document.data.as_tex()?.root_node();
-    let mut analyzer = ImportAnalyzer {
-        imports: Vec::new(),
-        diagnostics: Vec::new(),
-    };
-    analyzer.visit(&root);
-
-    Some(())
-}
-
-struct ImportAnalyzer {
-    imports: Vec<latex::SyntaxNode>,
-    diagnostics: Vec<Diagnostic>,
-}
-
-impl ImportAnalyzer {
-    fn visit(&mut self, node: &latex::SyntaxNode) {
-        match node.kind() {
-            latex::SyntaxKind::ROOT => {
-                let preamble = node
-                    .children()
-                    .filter(|child| child.kind() == SyntaxKind::PREAMBLE)
-                    .exactly_one()
-                    .unwrap();
-
-                self.visit(&preamble);
-            }
-            latex::SyntaxKind::PREAMBLE => {
-                for child in node.children() {
-                    if child.kind() == SyntaxKind::PACKAGE_INCLUDE {
-                        self.visit(&child);
-                    }
-                }
-            }
-            latex::SyntaxKind::PACKAGE_INCLUDE => {
-                for child in node.children() {
-                    if child.kind() == SyntaxKind::CURLY_GROUP_WORD_LIST {
-                        self.visit(&child);
-                    }
-                }
-            }
-            latex::SyntaxKind::CURLY_GROUP_WORD_LIST => {
-                for child in node.children() {
-                    if child.kind() == SyntaxKind::KEY {
-                        self.visit(&child);
-                    }
-                }
-            }
-            latex::SyntaxKind::KEY => {
-                self.imports.push(node.clone());
-            }
-            _ => (),
-        }
-    }
-
-    fn find_duplicates(&mut self) -> Option<()> {
-        let len = self.imports.len();
-        for i in 0..len {
-            for j in i..len {
-                if self.imports[i].text().to_string() == self.imports[j].text().to_string() {
-                    self.diagnostics.push(Diagnostic::Import(
-                        self.imports[j].text_range(),
-                        ImportError::DuplicateImport(vec![]),
-                    ));
-                }
-            }
-        }
-
-        Some(())
-    }
-}
 
 pub fn detect_duplicate_imports(
     workspace: &Workspace,
     results: &mut FxHashMap<Url, Vec<Diagnostic>>,
 ) {
-    log::debug!("IMPORT CONFLICT CHECK");
     for conflict in queries::Conflict::find_all::<Link>(workspace) {
-        log::debug!("IMPORT {:?}", conflict);
         let others = conflict
             .rest
             .iter()

--- a/crates/diagnostics/src/imports.rs
+++ b/crates/diagnostics/src/imports.rs
@@ -1,0 +1,106 @@
+use base_db::{semantics::tex::Link, util::queries, Document, Workspace};
+use itertools::Itertools;
+use rustc_hash::FxHashMap;
+use syntax::latex::{self, SyntaxKind};
+use url::Url;
+
+use crate::{types::Diagnostic, ImportError};
+
+pub(crate) fn update(
+    document: &Document,
+    _config: &base_db::Config,
+    _imports: &mut std::collections::HashMap<Url, Vec<Diagnostic>, rustc_hash::FxBuildHasher>,
+) -> Option<()> {
+    let root = document.data.as_tex()?.root_node();
+    let mut analyzer = ImportAnalyzer {
+        imports: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    analyzer.visit(&root);
+
+    Some(())
+}
+
+struct ImportAnalyzer {
+    imports: Vec<latex::SyntaxNode>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl ImportAnalyzer {
+    fn visit(&mut self, node: &latex::SyntaxNode) {
+        match node.kind() {
+            latex::SyntaxKind::ROOT => {
+                let preamble = node
+                    .children()
+                    .filter(|child| child.kind() == SyntaxKind::PREAMBLE)
+                    .exactly_one()
+                    .unwrap();
+
+                self.visit(&preamble);
+            }
+            latex::SyntaxKind::PREAMBLE => {
+                for child in node.children() {
+                    if child.kind() == SyntaxKind::PACKAGE_INCLUDE {
+                        self.visit(&child);
+                    }
+                }
+            }
+            latex::SyntaxKind::PACKAGE_INCLUDE => {
+                for child in node.children() {
+                    if child.kind() == SyntaxKind::CURLY_GROUP_WORD_LIST {
+                        self.visit(&child);
+                    }
+                }
+            }
+            latex::SyntaxKind::CURLY_GROUP_WORD_LIST => {
+                for child in node.children() {
+                    if child.kind() == SyntaxKind::KEY {
+                        self.visit(&child);
+                    }
+                }
+            }
+            latex::SyntaxKind::KEY => {
+                self.imports.push(node.clone());
+            }
+            _ => (),
+        }
+    }
+
+    fn find_duplicates(&mut self) -> Option<()> {
+        let len = self.imports.len();
+        for i in 0..len {
+            for j in i..len {
+                if self.imports[i].text().to_string() == self.imports[j].text().to_string() {
+                    self.diagnostics.push(Diagnostic::Import(
+                        self.imports[j].text_range(),
+                        ImportError::DuplicateImport(vec![]),
+                    ));
+                }
+            }
+        }
+
+        Some(())
+    }
+}
+
+pub fn detect_duplicate_imports(
+    workspace: &Workspace,
+    results: &mut FxHashMap<Url, Vec<Diagnostic>>,
+) {
+    log::debug!("IMPORT CONFLICT CHECK");
+    for conflict in queries::Conflict::find_all::<Link>(workspace) {
+        log::debug!("IMPORT {:?}", conflict);
+        let others = conflict
+            .rest
+            .iter()
+            .map(|location| (location.document.uri.clone(), location.range))
+            .collect();
+
+        let diagnostic =
+            Diagnostic::Import(conflict.main.range, ImportError::DuplicateImport(others));
+        results
+            .entry(conflict.main.document.uri.clone())
+            .or_default()
+            .push(diagnostic);
+    }
+}

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -5,6 +5,7 @@ mod grammar;
 mod labels;
 mod manager;
 mod types;
+mod imports;
 
 pub use manager::Manager;
 pub use types::*;

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -11,7 +11,6 @@ use crate::types::Diagnostic;
 /// Manages all diagnostics for a workspace.
 #[derive(Debug, Default)]
 pub struct Manager {
-    imports: FxHashMap<Url, Vec<Diagnostic>>,
     grammar: MultiMap<Url, Diagnostic>,
     chktex: FxHashMap<Url, Vec<Diagnostic>>,
     build_log: FxHashMap<Url, MultiMap<Url, Diagnostic>>,
@@ -31,11 +30,6 @@ impl Manager {
         self.build_log.remove(&document.uri);
         super::build_log::update(workspace, document, &mut self.build_log);
     }
-
-    /// Updates the import diagnostics for the given document.
-    //pub fn update_imports(&mut self, workspace: &Workspace, document: &Document) {
-        //super::imports::update(document, workspace.config(), &mut self.imports);
-    //}
 
     /// Updates the ChkTeX diagnostics for the given document.
     pub fn update_chktex(&mut self, uri: Url, diagnostics: Vec<Diagnostic>) {

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -11,6 +11,7 @@ use crate::types::Diagnostic;
 /// Manages all diagnostics for a workspace.
 #[derive(Debug, Default)]
 pub struct Manager {
+    imports: FxHashMap<Url, Vec<Diagnostic>>,
     grammar: MultiMap<Url, Diagnostic>,
     chktex: FxHashMap<Url, Vec<Diagnostic>>,
     build_log: FxHashMap<Url, MultiMap<Url, Diagnostic>>,
@@ -30,6 +31,11 @@ impl Manager {
         self.build_log.remove(&document.uri);
         super::build_log::update(workspace, document, &mut self.build_log);
     }
+
+    /// Updates the import diagnostics for the given document.
+    //pub fn update_imports(&mut self, workspace: &Workspace, document: &Document) {
+        //super::imports::update(document, workspace.config(), &mut self.imports);
+    //}
 
     /// Updates the ChkTeX diagnostics for the given document.
     pub fn update_chktex(&mut self, uri: Url, diagnostics: Vec<Diagnostic>) {
@@ -89,6 +95,7 @@ impl Manager {
         super::citations::detect_duplicate_entries(workspace, &mut results);
         super::labels::detect_duplicate_labels(workspace, &mut results);
         super::labels::detect_undefined_and_unused_labels(workspace, &mut results);
+        super::imports::detect_duplicate_imports(workspace, &mut results);
 
         results.retain(|uri, _| {
             workspace

--- a/crates/diagnostics/src/types.rs
+++ b/crates/diagnostics/src/types.rs
@@ -35,6 +35,12 @@ impl std::fmt::Debug for TexError {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ImportError {
+    OrderingConflict,
+    DuplicateImport(Vec<(Url, TextRange)>),
+}
+
 #[derive(PartialEq, Eq, Clone)]
 pub enum BibError {
     ExpectingLCurly,
@@ -89,6 +95,7 @@ pub enum Diagnostic {
     Bib(TextRange, BibError),
     Build(TextRange, BuildError),
     Chktex(ChktexError),
+    Import(TextRange, ImportError)
 }
 
 impl Diagnostic {
@@ -114,6 +121,10 @@ impl Diagnostic {
             },
             Diagnostic::Build(_, error) => &error.message,
             Diagnostic::Chktex(error) => &error.message,
+            Diagnostic::Import(_, error) => match error {
+                ImportError::OrderingConflict => todo!(),
+                ImportError::DuplicateImport(_) => "Duplicate Package imported.",
+            }
         }
     }
 
@@ -127,6 +138,7 @@ impl Diagnostic {
                 let end = line_index.offset(error.end)?;
                 TextRange::new(start, end)
             }
+            Diagnostic::Import(range, _) => *range,
         })
     }
 
@@ -152,6 +164,7 @@ impl Diagnostic {
             },
             Diagnostic::Chktex(_) => None,
             Diagnostic::Build(_, _) => None,
+            Diagnostic::Import(_, _) => None,
         }
     }
 }

--- a/crates/texlab/src/action.rs
+++ b/crates/texlab/src/action.rs
@@ -1,0 +1,188 @@
+use std::collections::HashMap;
+
+use base_db::Workspace;
+use diagnostics::{Diagnostic, ImportError};
+use lsp_types::{CodeAction, CodeActionKind, CodeActionParams, TextEdit, WorkspaceEdit};
+use rowan::{TextRange, TextSize};
+use rustc_hash::FxBuildHasher;
+
+use crate::util::{line_index_ext::LineIndexExt, to_proto};
+
+pub fn remove_duplicate_imports(
+    diagnostics_map: HashMap<lsp_types::Url, Vec<diagnostics::Diagnostic>, FxBuildHasher>,
+    params: CodeActionParams,
+    workspace: parking_lot::lock_api::RwLockReadGuard<'_, parking_lot::RawRwLock, Workspace>,
+) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+    let url = params.text_document.uri.clone();
+    let document = workspace.lookup(&url).unwrap();
+
+    let diagnostics = diagnostics_map
+        .get(&url)
+        .unwrap()
+        .iter()
+        .filter(|diag| matches!(diag, Diagnostic::Import(_, ImportError::DuplicateImport(_))))
+        .collect::<Vec<_>>();
+
+    let cursor_position = params.range.start;
+
+    let cursor_diag = diagnostics.iter().find(|diag| {
+        let line_index = &workspace
+            .lookup(&params.text_document.uri)
+            .unwrap()
+            .line_index;
+        let range = diag.range(&line_index).unwrap();
+        range.contains(line_index.offset_lsp(cursor_position).unwrap())
+    });
+
+    if let Some(diag) = cursor_diag {
+        let package_name = get_package_name(&workspace, &params, diag);
+
+        let filtered_diagnostics: Vec<_> = diagnostics.clone()
+            .into_iter()
+            .filter(|diag| get_package_name(&workspace, &params, diag) == package_name)
+            .collect();
+
+        let import_diags: Vec<lsp_types::Diagnostic> = filtered_diagnostics.clone()
+        .iter()
+        .map(|diag| to_proto::diagnostic(&workspace, document, diag).unwrap())
+        .collect();
+
+        for diag in filtered_diagnostics {
+            let line_index = &workspace
+                .lookup(&params.text_document.uri)
+                .unwrap()
+                .line_index;
+            let range = diag.range(&line_index).unwrap();
+            let start_line = line_index
+                .line_col_lsp_range(TextRange::at(range.start(), TextSize::from(0)))
+                .unwrap()
+                .start
+                .line;
+
+            actions.push(CodeAction {
+                title: format!(
+                    "Remove duplicate package: {}, line {}.",
+                    get_package_name(&workspace, &params, diag),
+                    (1 + start_line)
+                ),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: Some(import_diags.clone()),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(
+                        vec![(
+                            url.clone(),
+                            vec![TextEdit {
+                                range: get_line_range(&workspace, &params, diag),
+                                new_text: "".to_string(),
+                            }],
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    document_changes: None,
+                    change_annotations: None,
+                }),
+                command: None,
+                is_preferred: None,
+                disabled: None,
+                data: None,
+            });
+        }
+    }
+
+    let mut seen_packages = HashMap::new();
+    let all_diags = diagnostics
+        .iter()
+        .filter(|diag| {
+            let package_name = get_package_name(&workspace, &params, diag);
+            if seen_packages.contains_key(&package_name) {
+                true
+            } else {
+                seen_packages.insert(package_name, true);
+                false
+            }
+        })
+        .collect::<Vec<_>>();
+        
+    let mut all_diags_edit = Vec::new();
+
+
+    for diag in all_diags {
+        all_diags_edit.push(TextEdit {
+            range: get_line_range(&workspace, &params, diag),
+            new_text: "".to_string(),
+        });
+        
+    }    
+    
+    if all_diags_edit.is_empty() {
+        return actions;
+    }
+
+    let import_diags: Vec<lsp_types::Diagnostic> = diagnostics.clone()
+        .iter()
+        .map(|diag| to_proto::diagnostic(&workspace, document, diag).unwrap())
+        .collect();
+
+
+
+    actions.push(CodeAction {
+        title: "Remove all duplicate package.".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(import_diags.clone()),
+        edit: Some(WorkspaceEdit {
+            changes: Some(
+                vec![(
+                    url.clone(),
+                    all_diags_edit,
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
+
+    actions
+}
+
+fn get_line_range(
+    workspace: &Workspace,
+    params: &CodeActionParams,
+    diag: &Diagnostic,
+) -> lsp_types::Range {
+    let line_index = &workspace
+        .lookup(&params.text_document.uri)
+        .unwrap()
+        .line_index;
+    let range = diag.range(&line_index).unwrap();
+    let start_line = line_index
+        .line_col_lsp_range(TextRange::at(range.start(), TextSize::from(0)))
+        .unwrap()
+        .start
+        .line;
+    let end_line = line_index
+        .line_col_lsp_range(TextRange::new(range.end(), range.end()))
+        .unwrap()
+        .end
+        .line;
+    let start = lsp_types::Position::new(start_line, 0);
+    let end = lsp_types::Position::new(end_line + 1, 0);
+    lsp_types::Range::new(start, end)
+}
+
+fn get_package_name(workspace: &Workspace, params: &CodeActionParams, diag: &Diagnostic) -> String {
+    let document = workspace.lookup(&params.text_document.uri).unwrap();
+    let line_index = document.line_index.clone();
+    let range = diag.range(&line_index).unwrap();
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    let text = &document.text[start..end];
+    text.to_string()
+}

--- a/crates/texlab/src/action.rs
+++ b/crates/texlab/src/action.rs
@@ -38,15 +38,17 @@ pub fn remove_duplicate_imports(
     if let Some(diag) = cursor_diag {
         let package_name = get_package_name(&workspace, &params, diag);
 
-        let filtered_diagnostics: Vec<_> = diagnostics.clone()
+        let filtered_diagnostics: Vec<_> = diagnostics
+            .clone()
             .into_iter()
             .filter(|diag| get_package_name(&workspace, &params, diag) == package_name)
             .collect();
 
-        let import_diags: Vec<lsp_types::Diagnostic> = filtered_diagnostics.clone()
-        .iter()
-        .map(|diag| to_proto::diagnostic(&workspace, document, diag).unwrap())
-        .collect();
+        let import_diags: Vec<lsp_types::Diagnostic> = filtered_diagnostics
+            .clone()
+            .iter()
+            .map(|diag| to_proto::diagnostic(&workspace, document, diag).unwrap())
+            .collect();
 
         for diag in filtered_diagnostics {
             let line_index = &workspace
@@ -104,42 +106,32 @@ pub fn remove_duplicate_imports(
             }
         })
         .collect::<Vec<_>>();
-        
-    let mut all_diags_edit = Vec::new();
 
+    let mut all_diags_edit = Vec::new();
 
     for diag in all_diags {
         all_diags_edit.push(TextEdit {
             range: get_line_range(&workspace, &params, diag),
             new_text: "".to_string(),
         });
-        
-    }    
-    
+    }
+
     if all_diags_edit.is_empty() {
         return actions;
     }
 
-    let import_diags: Vec<lsp_types::Diagnostic> = diagnostics.clone()
+    let import_diags: Vec<lsp_types::Diagnostic> = diagnostics
+        .clone()
         .iter()
         .map(|diag| to_proto::diagnostic(&workspace, document, diag).unwrap())
         .collect();
-
-
 
     actions.push(CodeAction {
         title: "Remove all duplicate package.".to_string(),
         kind: Some(CodeActionKind::QUICKFIX),
         diagnostics: Some(import_diags.clone()),
         edit: Some(WorkspaceEdit {
-            changes: Some(
-                vec![(
-                    url.clone(),
-                    all_diags_edit,
-                )]
-                .into_iter()
-                .collect(),
-            ),
+            changes: Some(vec![(url.clone(), all_diags_edit)].into_iter().collect()),
             document_changes: None,
             change_annotations: None,
         }),

--- a/crates/texlab/src/lib.rs
+++ b/crates/texlab/src/lib.rs
@@ -2,6 +2,6 @@ mod client;
 pub(crate) mod features;
 mod server;
 pub(crate) mod util;
-mod actions;
+mod action;
 
 pub use self::{client::LspClient, server::Server};

--- a/crates/texlab/src/lib.rs
+++ b/crates/texlab/src/lib.rs
@@ -2,5 +2,6 @@ mod client;
 pub(crate) mod features;
 mod server;
 pub(crate) mod util;
+mod actions;
 
 pub use self::{client::LspClient, server::Server};

--- a/crates/texlab/src/server.rs
+++ b/crates/texlab/src/server.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use crate::action;
 use anyhow::Result;
 use base_db::{Owner, Workspace, deps};
 use commands::{BuildCommand, CleanCommand, CleanTarget, ForwardSearch};
@@ -808,9 +809,14 @@ impl Server {
         Ok(())
     }
 
-    fn code_actions(&self, id: RequestId, _params: CodeActionParams) -> Result<()> {
+    fn code_actions(&self, id: RequestId, params: CodeActionParams) -> Result<()> {
+        let workspace = self.workspace.read();
+        let diagnostics = self.diagnostic_manager.get(&workspace);
+
+        let actions = action::remove_duplicate_imports(diagnostics, params, workspace);
+
         self.client
-            .send_response(lsp_server::Response::new_ok(id, Vec::<CodeAction>::new()))?;
+            .send_response(lsp_server::Response::new_ok(id, actions))?;
         Ok(())
     }
 

--- a/crates/texlab/src/server.rs
+++ b/crates/texlab/src/server.rs
@@ -192,6 +192,7 @@ impl Server {
                 ]
                 .into_iter(),
             ))),
+            code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
             ..ServerCapabilities::default()
         }
     }

--- a/crates/texlab/src/util/to_proto.rs
+++ b/crates/texlab/src/util/to_proto.rs
@@ -5,7 +5,7 @@ use base_db::{
     data::BibtexEntryTypeCategory, util::RenderedObject,
 };
 use definition::DefinitionResult;
-use diagnostics::{BibError, ChktexSeverity, Diagnostic, TexError};
+use diagnostics::{BibError, ChktexSeverity, Diagnostic, ImportError, TexError};
 use folding::{FoldingRange, FoldingRangeKind};
 use highlights::{Highlight, HighlightKind};
 use hover::{Hover, HoverData};
@@ -28,9 +28,10 @@ pub fn diagnostic(
     diagnostic: &Diagnostic,
 ) -> Option<lsp_types::Diagnostic> {
     let range = match diagnostic {
-        Diagnostic::Tex(range, _) | Diagnostic::Bib(range, _) | Diagnostic::Build(range, _) => {
-            document.line_index.line_col_lsp_range(*range)?
-        }
+        Diagnostic::Tex(range, _)
+        | Diagnostic::Bib(range, _)
+        | Diagnostic::Build(range, _)
+        | Diagnostic::Import(range, _) => document.line_index.line_col_lsp_range(*range)?,
         Diagnostic::Chktex(range) => {
             let start = lsp_types::Position::new(range.start.line, range.start.col);
             let end = lsp_types::Position::new(range.end.line, range.end.col);
@@ -66,6 +67,10 @@ pub fn diagnostic(
             ChktexSeverity::Warning => lsp_types::DiagnosticSeverity::WARNING,
             ChktexSeverity::Error => lsp_types::DiagnosticSeverity::ERROR,
         },
+        Diagnostic::Import(_, error) => match error {
+            ImportError::OrderingConflict => lsp_types::DiagnosticSeverity::WARNING,
+            ImportError::DuplicateImport(_) => lsp_types::DiagnosticSeverity::ERROR,
+        },
     };
 
     let code: Option<NumberOrString> = match &diagnostic {
@@ -89,10 +94,14 @@ pub fn diagnostic(
         },
         Diagnostic::Build(_, _) => None,
         Diagnostic::Chktex(error) => Some(NumberOrString::String(error.code.clone())),
+        Diagnostic::Import(_, error) => match error {
+            ImportError::OrderingConflict => todo!(),
+            ImportError::DuplicateImport(_) => Some(NumberOrString::Number(15)),
+        },
     };
 
     let source = match &diagnostic {
-        Diagnostic::Tex(_, _) | Diagnostic::Bib(_, _) => "texlab",
+        Diagnostic::Tex(_, _) | Diagnostic::Bib(_, _) | Diagnostic::Import(_, _) => "texlab",
         Diagnostic::Build(_, _) => "latex",
         Diagnostic::Chktex(_) => "ChkTeX",
     };
@@ -118,6 +127,10 @@ pub fn diagnostic(
         },
         Diagnostic::Build(_, error) => &error.message,
         Diagnostic::Chktex(error) => &error.message,
+        Diagnostic::Import(_, error) => match error {
+            ImportError::OrderingConflict => "Possible Conflict in Package Ordering.",
+            ImportError::DuplicateImport(_) => "Duplicate Package."
+        }
     });
 
     let tags = match &diagnostic {
@@ -141,6 +154,10 @@ pub fn diagnostic(
         },
         Diagnostic::Build(_, _) => None,
         Diagnostic::Chktex(_) => None,
+        Diagnostic::Import(_, error) => match error {
+            ImportError::DuplicateImport(_) => Some(vec![lsp_types::DiagnosticTag::UNNECESSARY]),
+            _ => None,
+        },
     };
 
     fn make_conflict_info(
@@ -184,6 +201,10 @@ pub fn diagnostic(
         },
         Diagnostic::Build(_, _) => None,
         Diagnostic::Chktex(_) => None,
+        Diagnostic::Import(_, error) => match error {
+            ImportError::OrderingConflict => None,
+            ImportError::DuplicateImport(others) => make_conflict_info(workspace, others, "package"),
+        }
     };
 
     Some(lsp_types::Diagnostic {


### PR DESCRIPTION
Making this draft PR to gauge interest and get feedback from upstream.

This PR does the following:

- Creates diagnostics to check for duplicate `\usepackage` statements.
- Creates code actions to remove some or all of the duplicate packages.

This is just a test run of writing code actions. If there is interest, I plan to write a check for conflicting package ordering (e.g. hyperref), and possibly a code action to correct the package order. 

Some comments:
- I called these `\usepackage` statements Imports (i.e. `Diagnostic::ImportError`) in the diagnostic error enums before I remembered there is an `\import` command. I will probably rename these enum variants to avoid confusion.
-  This probably duplicates some functionality from elsewhere, e.g.`to_proto`. If you see something obvious, please leave me a comment and I will refactor as needed.