### PR TITLE
Allow user-defined document symbol environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow hovering over symbol-like commands (e. g. `\pi`) to show a unicode preview
   or a preview image if the client supports it ([#1261](https://github.com/latex-lsp/texlab/issues/1261))
+- Add `texlab.symbols.customEnvironments` setting for specifying additional environments that will be included in the document symbols
+  ([#1292](https://github.com/latex-lsp/texlab/issues/1292))
 
 ## [5.21.0] - 2024-10-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "line-index",
  "regex",
  "rowan",
+ "rustc-hash 2.1.0",
  "syntax",
  "test-utils",
  "titlecase",
@@ -1608,6 +1609,7 @@ dependencies = [
  "syntax",
  "tempfile",
  "threadpool",
+ "titlecase",
 ]
 
 [[package]]

--- a/crates/base-db/src/config.rs
+++ b/crates/base-db/src/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use parser::SyntaxConfig;
 use regex::Regex;
+use rustc_hash::FxHashMap;
 
 #[derive(Debug, Default)]
 pub struct Config {
@@ -75,6 +76,13 @@ pub struct LatexIndentConfig {
 pub struct SymbolConfig {
     pub allowed_patterns: Vec<Regex>,
     pub ignored_patterns: Vec<Regex>,
+    pub custom_environments: FxHashMap<String, SymbolEnvironmentConfig>,
+}
+
+#[derive(Debug, Default)]
+pub struct SymbolEnvironmentConfig {
+    pub display_name: String,
+    pub label: bool,
 }
 
 #[derive(Debug)]

--- a/crates/base-db/src/semantics/tex.rs
+++ b/crates/base-db/src/semantics/tex.rs
@@ -50,7 +50,7 @@ impl Semantics {
                 }
                 latex::SyntaxElement::Token(token) => match token.kind() {
                     latex::COMMAND_NAME => {
-                            self.commands.push(Span::command(&token));
+                        self.commands.push(Span::command(&token));
                     }
                     latex::COMMENT if token.text().contains("texlab: ignore") => {
                         self.diagnostic_suppressions.push(token.text_range());
@@ -341,9 +341,7 @@ impl Semantics {
     fn process_bibitem(&mut self, bibitem: latex::BibItem) {
         if let Some(name) = bibitem.name() {
             if let Some(key) = name.key() {
-                self.bibitems.insert(
-                    Span::from(&key)
-                );
+                self.bibitems.insert(Span::from(&key));
             }
         }
     }

--- a/crates/diagnostics/src/citations.rs
+++ b/crates/diagnostics/src/citations.rs
@@ -18,7 +18,10 @@ pub fn detect_undefined_citations<'a>(
 ) -> Option<()> {
     let data = document.data.as_tex()?;
 
-    let bibitems: FxHashSet<&str> = data.semantics.bibitems.iter()
+    let bibitems: FxHashSet<&str> = data
+        .semantics
+        .bibitems
+        .iter()
         .map(|bib| bib.text.as_str())
         .collect();
 
@@ -45,13 +48,11 @@ pub fn detect_unused_entries<'a>(
     document: &'a Document,
     results: &mut FxHashMap<Url, Vec<Diagnostic>>,
 ) -> Option<()> {
-
     let citations: FxHashSet<&str> = Citation::find_all(project)
         .map(|(_, citation)| citation.name_text())
         .collect();
 
-    if let Some(data) = document.data.as_bib()
-    {
+    if let Some(data) = document.data.as_bib() {
         // If this is a huge bibliography, then don't bother checking for unused entries.
         if data.semantics.entries.len() > MAX_UNUSED_ENTRIES {
             return None;
@@ -68,7 +69,7 @@ pub fn detect_unused_entries<'a>(
         }
     };
 
-    if let Some(tex_data) = document.data.as_tex(){
+    if let Some(tex_data) = document.data.as_tex() {
         for bibitem in &tex_data.semantics.bibitems {
             if !citations.contains(bibitem.text.as_str()) {
                 let diagnostic = Diagnostic::Bib(bibitem.range, BibError::UnusedEntry);

--- a/crates/parser/src/latex.rs
+++ b/crates/parser/src/latex.rs
@@ -1296,7 +1296,6 @@ impl<'a> Parser<'a> {
 
         self.builder.finish_node();
     }
-
 }
 
 pub fn parse_latex(text: &str, config: &SyntaxConfig) -> GreenNode {

--- a/crates/symbols/Cargo.toml
+++ b/crates/symbols/Cargo.toml
@@ -20,6 +20,7 @@ titlecase.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-regex.workspace = true
-test-utils = { path = "../test-utils" }
 expect-test.workspace = true
+regex.workspace = true
+rustc-hash.workspace = true
+test-utils = { path = "../test-utils" }

--- a/crates/symbols/src/types.rs
+++ b/crates/symbols/src/types.rs
@@ -14,6 +14,7 @@ pub enum SymbolKind {
     Equation,
     Entry(BibtexEntryTypeCategory),
     Field,
+    Environment,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -70,6 +71,7 @@ impl Symbol {
             }
             SymbolKind::Entry(_) => vec![&self.name, "bibtex", "entry"],
             SymbolKind::Field => vec![&self.name, "bibtex", "field"],
+            SymbolKind::Environment => vec![&self.name, "latex", "environment"],
         }
     }
 

--- a/crates/texlab/Cargo.toml
+++ b/crates/texlab/Cargo.toml
@@ -45,8 +45,8 @@ links = { path = "../links" }
 log.workspace = true
 lsp-server = "0.7.7"
 lsp-types = "0.95.1"
-notify.workspace = true
 notify-debouncer-full = "0.3.2"
+notify.workspace = true
 parking_lot = "0.12.3"
 parser = { path = "../parser" }
 references = { path = "../references" }
@@ -54,14 +54,15 @@ regex.workspace = true
 rename = { path = "../rename" }
 rowan.workspace = true
 rustc-hash.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 serde_regex = "1.1.0"
 serde_repr = "0.1.19"
+serde.workspace = true
 symbols = { path = "../symbols" }
 syntax = { path = "../syntax" }
 tempfile.workspace = true
 threadpool = "1.8.1"
+titlecase.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/texlab/src/features/formatting/latexindent.rs
+++ b/crates/texlab/src/features/formatting/latexindent.rs
@@ -74,10 +74,10 @@ fn build_arguments(config: &LatexIndentConfig, target_file: &Path) -> Vec<String
 
     match &config.replacement {
         Some(replacement_flag) => {
-            if ["-r", "-rv", "-rr"].contains(& replacement_flag.as_str()) {
+            if ["-r", "-rv", "-rr"].contains(&replacement_flag.as_str()) {
                 args.push(replacement_flag.clone());
             }
-        },
+        }
         None => {}
     }
 

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -114,6 +114,16 @@ pub struct InlayHintOptions {
 pub struct SymbolOptions {
     pub allowed_patterns: Vec<RegexPattern>,
     pub ignored_patterns: Vec<RegexPattern>,
+    pub custom_environments: Vec<SymbolEnvironmentOptions>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct SymbolEnvironmentOptions {
+    pub name: String,
+    pub display_name: Option<String>,
+    pub label: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/texlab/src/util/from_proto.rs
+++ b/crates/texlab/src/util/from_proto.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use base_db::{Config, FeatureParams, Formatter, SynctexConfig, Workspace};
+use base_db::{
+    Config, FeatureParams, Formatter, SymbolEnvironmentConfig, SynctexConfig, Workspace,
+};
 use completion::CompletionParams;
 use definition::DefinitionParams;
 use highlights::HighlightParams;
@@ -9,6 +11,7 @@ use inlay_hints::InlayHintParams;
 use references::ReferenceParams;
 use rename::RenameParams;
 use rowan::TextSize;
+use titlecase::titlecase;
 
 use crate::{
     features::completion::ResolveInfo,
@@ -313,6 +316,23 @@ pub fn config(value: Options) -> Config {
         .ignored_patterns
         .into_iter()
         .map(|pattern| pattern.0)
+        .collect();
+
+    config.symbols.custom_environments = value
+        .symbols
+        .custom_environments
+        .into_iter()
+        .map(|env| {
+            let display_name = env.display_name.unwrap_or_else(|| titlecase(&env.name));
+            let label = env.label.unwrap_or_default();
+
+            let config = SymbolEnvironmentConfig {
+                display_name,
+                label,
+            };
+
+            (env.name, config)
+        })
         .collect();
 
     config.inlay_hints.label_definitions = value.inlay_hints.label_definitions.unwrap_or(true);

--- a/crates/texlab/src/util/to_proto.rs
+++ b/crates/texlab/src/util/to_proto.rs
@@ -380,6 +380,7 @@ pub fn symbol_kind(value: symbols::SymbolKind) -> lsp_types::SymbolKind {
             BibtexEntryTypeCategory::Collection => lsp_types::SymbolKind::TYPE_PARAMETER,
         },
         symbols::SymbolKind::Field => lsp_types::SymbolKind::FIELD,
+        symbols::SymbolKind::Environment => lsp_types::SymbolKind::FUNCTION,
     }
 }
 


### PR DESCRIPTION
Add `texlab.symbols.customEnvironments` setting.

Fixes #1292.