### PR TITLE
Add setting for custom label reference range cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or a preview image if the client supports it ([#1261](https://github.com/latex-lsp/texlab/issues/1261))
 - Add `texlab.symbols.customEnvironments` setting for specifying additional environments that will be included in the document symbols
   ([#1292](https://github.com/latex-lsp/texlab/issues/1292))
+- Add `texlab.experimental.labelReferenceRangeCommands` setting ([#1210](https://github.com/latex-lsp/texlab/issues/1210))
 
 ## [5.21.0] - 2024-10-26
 

--- a/crates/parser/src/config.rs
+++ b/crates/parser/src/config.rs
@@ -12,6 +12,7 @@ pub struct SyntaxConfig {
     pub label_definition_prefixes: Vec<(String, String)>,
     pub label_reference_commands: FxHashSet<String>,
     pub label_reference_prefixes: Vec<(String, String)>,
+    pub label_reference_range_commands: FxHashSet<String>,
 }
 
 impl Default for SyntaxConfig {
@@ -56,6 +57,11 @@ impl Default for SyntaxConfig {
             .map(|(x, y)| (ToString::to_string(x), ToString::to_string(y)))
             .collect();
 
+        let label_reference_range_commands = DEFAULT_LABEL_REFERENCE_RANGE_COMMANDS
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
         Self {
             follow_package_links: false,
             use_file_list: false,
@@ -67,6 +73,7 @@ impl Default for SyntaxConfig {
             label_definition_prefixes,
             label_reference_commands,
             label_reference_prefixes,
+            label_reference_range_commands,
         }
     }
 }
@@ -216,3 +223,14 @@ static DEFAULT_LABEL_REFERENCE_COMMANDS: &[&str] = &[
 ];
 
 static DEFAULT_LABEL_REFERENCE_PREFIXES: &[(&str, &str)] = &[];
+
+static DEFAULT_LABEL_REFERENCE_RANGE_COMMANDS: &[&str] = &[
+    "crefrange",
+    "crefrange*",
+    "Crefrange",
+    "Crefrange*",
+    "vrefrange",
+    "vrefrange*",
+    "vpagerefrange",
+    "vpagerefrange*",
+];

--- a/crates/parser/src/latex/lexer/commands.rs
+++ b/crates/parser/src/latex/lexer/commands.rs
@@ -29,7 +29,6 @@ pub fn classify(name: &str, config: &SyntaxConfig) -> CommandName {
         "import" | "subimport" | "inputfrom" | "subinputfrom" | "subincludefrom" => {
             CommandName::Import
         }
-        "crefrange" | "crefrange*" | "Crefrange" | "Crefrange*" => CommandName::LabelReferenceRange,
         "newlabel" => CommandName::LabelNumber,
         "def" | "let" => CommandName::OldCommandDefinition,
         "newcommand"
@@ -103,6 +102,9 @@ pub fn classify(name: &str, config: &SyntaxConfig) -> CommandName {
         _ if config.citation_commands.contains(name) => CommandName::Citation,
         _ if config.label_definition_commands.contains(name) => CommandName::LabelDefinition,
         _ if config.label_reference_commands.contains(name) => CommandName::LabelReference,
+        _ if config.label_reference_range_commands.contains(name) => {
+            CommandName::LabelReferenceRange
+        }
         _ => CommandName::Generic,
     }
 }

--- a/crates/texlab/src/server/options.rs
+++ b/crates/texlab/src/server/options.rs
@@ -142,6 +142,7 @@ pub struct ExperimentalOptions {
     pub label_definition_prefixes: Vec<(String, String)>,
     pub label_reference_commands: Vec<String>,
     pub label_reference_prefixes: Vec<(String, String)>,
+    pub label_reference_range_commands: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize)]

--- a/crates/texlab/src/util/from_proto.rs
+++ b/crates/texlab/src/util/from_proto.rs
@@ -389,4 +389,9 @@ pub fn config(value: Options) -> Config {
         .extend(value.experimental.label_reference_prefixes);
 
     config
+        .syntax
+        .label_reference_range_commands
+        .extend(value.experimental.label_reference_range_commands);
+
+    config
 }


### PR DESCRIPTION
Add `texlab.experimental.labelReferenceRangeCommands`.

Fixes #1210.