### PR TITLE
feat: add ```warnings: on``` and ```warnings: off```

### DIFF
--- a/crates/base-db/src/semantics/tex.rs
+++ b/crates/base-db/src/semantics/tex.rs
@@ -56,13 +56,13 @@ impl Semantics {
                     latex::COMMENT if token.text().contains("texlab: ignore") => {
                         self.diagnostic_suppressions.push(token.text_range());
                     }
-                    latex::COMMENT if token.text().contains("warnings: off") => {
+                    latex::COMMENT if token.text().contains("texlab: warnings off") => {
                         let start_range = token.text_range();
                         let mut current = token.clone();
                         while let Some(next) = current.next_token() {
                             current = next;
                             if current.kind() == latex::COMMENT
-                                && current.text().contains("warnings: on")
+                                && current.text().contains("texlab: warnings on")
                             {
                                 self.warning_suppression_ranges
                                     .push((start_range, current.text_range()));

--- a/crates/base-db/src/semantics/tex.rs
+++ b/crates/base-db/src/semantics/tex.rs
@@ -38,6 +38,7 @@ pub struct Semantics {
     pub can_be_root: bool,
     pub can_be_compiled: bool,
     pub diagnostic_suppressions: Vec<TextRange>,
+    pub warning_suppression_ranges: Vec<(TextRange, TextRange)>,
     pub bibitems: FxHashSet<Span>,
 }
 
@@ -54,6 +55,20 @@ impl Semantics {
                     }
                     latex::COMMENT if token.text().contains("texlab: ignore") => {
                         self.diagnostic_suppressions.push(token.text_range());
+                    }
+                    latex::COMMENT if token.text().contains("warnings: off") => {
+                        let start_range = token.text_range();
+                        let mut current = token.clone();
+                        while let Some(next) = current.next_token() {
+                            current = next;
+                            if current.kind() == latex::COMMENT
+                                && current.text().contains("warnings: on")
+                            {
+                                self.warning_suppression_ranges
+                                    .push((start_range, current.text_range()));
+                                break;
+                            }
+                        }
                     }
                     _ => {}
                 },

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -158,10 +158,31 @@ impl Manager {
 
         let diag_line_col = document.line_index.line_col(diag_range.start());
 
-        data.semantics
+        let is_single_line_suppressed = data
+            .semantics
             .diagnostic_suppressions
             .iter()
             .map(|r| document.line_index.line_col(r.start()))
-            .any(|r| r.line == diag_line_col.line || r.line + 1 == diag_line_col.line)
+            .any(|r| r.line == diag_line_col.line || r.line + 1 == diag_line_col.line);
+
+        if is_single_line_suppressed {
+            return true;
+        }
+
+        let is_in_suppression_range =
+            data.semantics
+                .warning_suppression_ranges
+                .iter()
+                .any(|(start, end)| {
+                    let start_line = document.line_index.line_col(start.start()).line;
+                    let end_line = document.line_index.line_col(end.start()).line;
+                    diag_line_col.line > start_line && diag_line_col.line < end_line
+                });
+
+        if is_in_suppression_range {
+            return true;
+        }
+
+        false
     }
 }

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -157,6 +157,7 @@ impl Manager {
         };
 
         let diag_line_col = document.line_index.line_col(diag_range.start());
+        let diag_offset = diag_range.start();
 
         let is_single_line_suppressed = data
             .semantics
@@ -176,7 +177,8 @@ impl Manager {
                 .any(|(start, end)| {
                     let start_line = document.line_index.line_col(start.start()).line;
                     let end_line = document.line_index.line_col(end.start()).line;
-                    diag_line_col.line > start_line && diag_line_col.line <= end_line
+                    let end_offset = end.end();
+                    diag_line_col.line > start_line && diag_offset <= end_offset
                 });
 
         if is_in_suppression_range {

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -176,7 +176,6 @@ impl Manager {
                 .iter()
                 .any(|(start, end)| {
                     let start_line = document.line_index.line_col(start.start()).line;
-                    let end_line = document.line_index.line_col(end.start()).line;
                     let end_offset = end.end();
                     diag_line_col.line > start_line && diag_offset <= end_offset
                 });

--- a/crates/diagnostics/src/manager.rs
+++ b/crates/diagnostics/src/manager.rs
@@ -176,7 +176,7 @@ impl Manager {
                 .any(|(start, end)| {
                     let start_line = document.line_index.line_col(start.start()).line;
                     let end_line = document.line_index.line_col(end.start()).line;
-                    diag_line_col.line > start_line && diag_line_col.line < end_line
+                    diag_line_col.line > start_line && diag_line_col.line <= end_line
                 });
 
         if is_in_suppression_range {


### PR DESCRIPTION
Closes https://github.com/latex-lsp/texlab/issues/1327. Superseeds https://github.com/latex-lsp/texlab/pull/1329.

Disables all warnings in an off/on block.
```latex
% warnings: off
\coordinate (B) at ($(A) + (0, 4)$);
\coordinate (C) at ($(B) + (3, 0)$);
\coordinate (D) at ($(A) + (3, 0)$);
% warnings: on
```