### PR TITLE
Capabilities for LSP extensions

### DIFF
--- a/crates/texlab/src/server.rs
+++ b/crates/texlab/src/server.rs
@@ -23,6 +23,7 @@ use notify_debouncer_full::{DebouncedEvent, Debouncer, RecommendedCache};
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashSet;
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{Map, Value};
 use threadpool::ThreadPool;
 
 use crate::{
@@ -174,6 +175,13 @@ impl Server {
                 ..Default::default()
             }),
             inlay_hint_provider: Some(OneOf::Left(true)),
+            experimental: Some(Value::Object(Map::from_iter(
+                [
+                    ("textDocumentBuild".to_string(), Value::Bool(true)),
+                    ("textDocumentForwardSearch".to_string(), Value::Bool(true)),
+                ]
+                .into_iter(),
+            ))),
             ..ServerCapabilities::default()
         }
     }


### PR DESCRIPTION
Clients sending textDocument/build to a server that doesn't support
it may receive an error.  In a multi-server setup, users expect to
send the message only to servers that support it.  Add a capability
to enable this use case.

To-do: add this to https://github.com/latex-lsp/texlab/wiki/LSP-Internals

Closes #1328
