### PR TITLE
Add bounds check to prevent panic in completion

### DIFF
--- a/crates/completion/src/providers/command.rs
+++ b/crates/completion/src/providers/command.rs
@@ -138,6 +138,10 @@ fn find_command_name_ast<L: rowan::Language>(
     kind: L::Kind,
     offset: TextSize,
 ) -> Option<Span> {
+    // `token_at_offset` will panic if offset is not within the range of `root`.
+    if !root.text_range().contains(offset) {
+        return None;
+    }
     let token = root
         .token_at_offset(offset)
         .filter(|token| token.text_range().start() != offset)


### PR DESCRIPTION
TexLab will panic if it receives a completion request with an invalid offset. This PR prevents the panic by checking if the `offset` is in range before passing it to `token_at_offset`.

As noted in the docs of `token_at_offset`:
> Precondition: offset must be withing node's range.