### PR TITLE
handle nested curly_group_word_list

### DIFF
--- a/crates/parser/src/latex.rs
+++ b/crates/parser/src/latex.rs
@@ -267,12 +267,15 @@ impl<'a> Parser<'a> {
                         | Token::Word
                         | Token::Pipe
                         | Token::Comma
+                        | Token::LCurly
                 )
             })
             .is_some()
         {
             if self.peek() == Some(Token::Word) {
                 self.key();
+            } else if self.peek() == Some(Token::LCurly) {
+                self.curly_group_word_list();
             } else {
                 self.eat();
             }

--- a/crates/parser/src/latex/tests.rs
+++ b/crates/parser/src/latex/tests.rs
@@ -4228,3 +4228,29 @@ fn test_url_with_parentheses_and_percent_encoding() {
         "#]],
     );
 }
+
+#[test]
+fn test_double_bracket_curly_group_word_list() {
+    check(
+        r#"Some text.~\eqref{{eq:test}}"#,
+        expect![[r#"
+            ROOT@0..28
+              PREAMBLE@0..28
+                TEXT@0..11
+                  WORD@0..4 "Some"
+                  WHITESPACE@4..5 " "
+                  WORD@5..11 "text.~"
+                LABEL_REFERENCE@11..28
+                  COMMAND_NAME@11..17 "\\eqref"
+                  CURLY_GROUP_WORD_LIST@17..28
+                    L_CURLY@17..18 "{"
+                    CURLY_GROUP_WORD_LIST@18..27
+                      L_CURLY@18..19 "{"
+                      KEY@19..26
+                        WORD@19..26 "eq:test"
+                      R_CURLY@26..27 "}"
+                    R_CURLY@27..28 "}"
+
+        "#]],
+    );
+}

--- a/crates/syntax/src/latex/cst.rs
+++ b/crates/syntax/src/latex/cst.rs
@@ -209,7 +209,7 @@ impl HasCurly for CurlyGroupWordList {}
 
 impl CurlyGroupWordList {
     pub fn keys(&self) -> impl Iterator<Item = Key> {
-        self.syntax().children().filter_map(Key::cast)
+        self.syntax().descendants().filter_map(Key::cast)
     }
 }
 


### PR DESCRIPTION
Fixes issue #1360 

Modifies curly_group_word_list() to check for Token::LCurly and create a child curly_group_word_list node.
In cst.rs we change the CurlyGroupWordList::keys() function to check descendants instead of only checking children so that the label reference is not missed by the parser.
The new behavior is as follows:

``` latex
\eqref{{eq:test} % Triggers a missing } diagnostic and an undefined reference diagnostics
\eqref{eq:test}} % Triggers an extra } diagnostic and an undefined reference diagnostics
\eqref{eq:test} % Triggers an undefined reference diagnostic, but no brace diagnostics
\eqref{{eq:test}} % Triggers an undefined reference diagnostic, but no brace diagnostics
```