### PR TITLE
Add one-based line number to inverse search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `--line0`, `--line1` arguments to the `texlab inverse-search` command ([#1365](https://github.com/latex-lsp/texlab/issues/1365))
+
 ## [5.22.1] - 2025-01-29
 
 ### Security


### PR DESCRIPTION
- Add `--line0` and `--line1` command line arguments to `texlab inverse-search`
- For compatibility, `--line` stays an alias for `--line0`

Fixes #1365.