### PR TITLE
Bugfix/issue1376

### DIFF
--- a/crates/parser/src/latexmkrc.rs
+++ b/crates/parser/src/latexmkrc.rs
@@ -12,19 +12,10 @@ mod v483 {
 
     pub fn parse_latexmkrc(input: &str, src_dir: &Path) -> std::io::Result<LatexmkrcData> {
         let temp_dir = tempdir()?;
-        let non_existent_tex = temp_dir.path().join("NONEXISTENT.tex");
         std::fs::write(temp_dir.path().join(".latexmkrc"), input)?;
 
-        // Run `latexmk -dir-report $TMPDIR/NONEXISTENT.tex` to obtain out_dir
-        // and aux_dir values. We pass nonexistent file to prevent latexmk from
-        // building anything, since we need this invocation only to extract the
-        // -dir-report variables.
-        //
-        // In later versions, latexmk provides the -dir-report-only option and we
-        // won't have to resort to this hack with NONEXISTENT.tex.
         let output = std::process::Command::new("latexmk")
-            .arg("-dir-report")
-            .arg(non_existent_tex)
+            .arg("-dir-report-only")
             .current_dir(temp_dir.path())
             .output()?;
 

--- a/crates/parser/src/latexmkrc.rs
+++ b/crates/parser/src/latexmkrc.rs
@@ -12,10 +12,19 @@ mod v483 {
 
     pub fn parse_latexmkrc(input: &str, src_dir: &Path) -> std::io::Result<LatexmkrcData> {
         let temp_dir = tempdir()?;
+        let non_existent_tex = temp_dir.path().join("NONEXISTENT.tex");
         std::fs::write(temp_dir.path().join(".latexmkrc"), input)?;
 
+        // Run `latexmk -dir-report $TMPDIR/NONEXISTENT.tex` to obtain out_dir
+        // and aux_dir values. We pass nonexistent file to prevent latexmk from
+        // building anything, since we need this invocation only to extract the
+        // -dir-report variables.
+        //
+        // In later versions, latexmk provides the -dir-report-only option and we
+        // won't have to resort to this hack with NONEXISTENT.tex.
         let output = std::process::Command::new("latexmk")
-            .arg("-dir-report-only")
+            .arg("-dir-report")
+            .arg(non_existent_tex)
             .current_dir(temp_dir.path())
             .output()?;
 

--- a/crates/texlab/src/server.rs
+++ b/crates/texlab/src/server.rs
@@ -1132,6 +1132,7 @@ impl Server {
 
                 log::info!("Detected distribution: {:?}", distro.kind);
                 sender.send(InternalMessage::SetDistro(distro)).unwrap();
+
                 drop(progress_reporter);
             });
         }

--- a/crates/texlab/src/server.rs
+++ b/crates/texlab/src/server.rs
@@ -1110,16 +1110,17 @@ impl Server {
 
     pub fn run(mut self, options: StartupOptions) -> Result<()> {
         if !options.skip_distro {
-            let sender = self.internal_tx.clone();
-            self.pool.execute(move || {
+            //let sender = self.internal_tx.clone();
+            //self.pool.execute(move || {
                 let distro = Distro::detect().unwrap_or_else(|why| {
                     log::warn!("Unable to load distro files: {}", why);
                     Distro::default()
                 });
 
                 log::info!("Detected distribution: {:?}", distro.kind);
-                sender.send(InternalMessage::SetDistro(distro)).unwrap();
-            });
+                self.workspace.write().set_distro(distro);
+                //sender.send(InternalMessage::SetDistro(distro)).unwrap();
+            //});
         }
 
         self.register_configuration();

--- a/crates/texlab/src/server/progress.rs
+++ b/crates/texlab/src/server/progress.rs
@@ -24,6 +24,7 @@ impl Drop for ProgressReporter {
 }
 
 impl ProgressReporter {
+    //pub fn new_build_progress(client: LspClient, token: i32, uri: &Url) -> Self {
     pub fn new(client: LspClient, token: i32, uri: &Url) -> Self {
         let _ = client.send_request::<WorkDoneProgressCreate>(WorkDoneProgressCreateParams {
             token: NumberOrString::Number(token),
@@ -34,6 +35,24 @@ impl ProgressReporter {
             value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(WorkDoneProgressBegin {
                 title: "Building".into(),
                 message: Some(String::from(uri.as_str())),
+                cancellable: Some(false),
+                percentage: None,
+            })),
+        });
+
+        Self { client, token }
+    }
+
+    pub fn new_inputs_progress(client: LspClient, token: i32) -> Self {
+        let _ = client.send_request::<WorkDoneProgressCreate>(WorkDoneProgressCreateParams {
+            token: NumberOrString::Number(token),
+        });
+
+        let _ = client.send_notification::<Progress>(ProgressParams {
+            token: NumberOrString::Number(token),
+            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(WorkDoneProgressBegin {
+                title: "Parsing Dependencies.".into(),
+                message: None,
                 cancellable: Some(false),
                 percentage: None,
             })),


### PR DESCRIPTION
Fixes #1376 
After distro detection, calls update_workspace() to update diagnostics after bib files from $BIBINPUTS are read.
Notifies the client that it is still parsing dependencies.