### PR TITLE
Improve `workspace/symbol` filtering

### DIFF
--- a/crates/symbols/src/types.rs
+++ b/crates/symbols/src/types.rs
@@ -56,23 +56,24 @@ impl Symbol {
     }
 
     pub fn keywords(&self) -> Vec<&str> {
-        match self.kind {
-            SymbolKind::Section => vec![&self.name, "latex", "section"],
-            SymbolKind::Figure => vec![&self.name, "latex", "float", "figure"],
-            SymbolKind::Algorithm => vec![&self.name, "latex", "float", "algorithm"],
-            SymbolKind::Table => vec![&self.name, "latex", "float", "table"],
-            SymbolKind::Listing => vec![&self.name, "latex", "float", "listing"],
-            SymbolKind::Enumeration => vec![&self.name, "latex", "enumeration"],
-            SymbolKind::EnumerationItem => vec![&self.name, "latex", "enumeration", "item"],
-            SymbolKind::Theorem => vec![&self.name, "latex", "math"],
-            SymbolKind::Equation => vec![&self.name, "latex", "math", "equation"],
-            SymbolKind::Entry(BibtexEntryTypeCategory::String) => {
-                vec![&self.name, "bibtex", "string"]
-            }
-            SymbolKind::Entry(_) => vec![&self.name, "bibtex", "entry"],
-            SymbolKind::Field => vec![&self.name, "bibtex", "field"],
-            SymbolKind::Environment => vec![&self.name, "latex", "environment"],
-        }
+        let name = self.name.split_whitespace();
+        let tags = match self.kind {
+            SymbolKind::Section => vec!["latex", "section"],
+            SymbolKind::Figure => vec!["latex", "float", "figure"],
+            SymbolKind::Algorithm => vec!["latex", "float", "algorithm"],
+            SymbolKind::Table => vec!["latex", "float", "table"],
+            SymbolKind::Listing => vec!["latex", "float", "listing"],
+            SymbolKind::Enumeration => vec!["latex", "enumeration"],
+            SymbolKind::EnumerationItem => vec!["latex", "enumeration", "item"],
+            SymbolKind::Theorem => vec!["latex", "math"],
+            SymbolKind::Equation => vec!["latex", "math", "equation"],
+            SymbolKind::Entry(BibtexEntryTypeCategory::String) => vec!["bibtex", "string"],
+            SymbolKind::Entry(_) => vec!["bibtex", "entry"],
+            SymbolKind::Field => vec!["bibtex", "field"],
+            SymbolKind::Environment => vec!["latex", "environment"],
+        };
+
+        name.chain(tags).collect()
     }
 
     pub fn flatten(mut self, buffer: &mut Vec<Self>) {

--- a/crates/symbols/src/workspace.rs
+++ b/crates/symbols/src/workspace.rs
@@ -26,7 +26,7 @@ pub fn workspace_symbols<'a>(workspace: &'a Workspace, query: &str) -> Vec<Symbo
             let keywords = symbol.keywords();
             if query.is_empty()
                 || itertools::iproduct!(keywords.iter(), query.iter())
-                    .any(|(keyword, query)| keyword.eq_ignore_ascii_case(query))
+                    .any(|(keyword, query)| keyword.to_lowercase().contains(&query.to_lowercase()))
             {
                 results.push(SymbolLocation { document, symbol });
             }

--- a/crates/symbols/src/workspace/tests.rs
+++ b/crates/symbols/src/workspace/tests.rs
@@ -42,6 +42,8 @@ static FIXTURE: &str = r#"
     Qux
 \end{lemma}
 
+\section{Foo bar}\label{sec:foobar}
+
 \end{document}
 
 %! main.aux
@@ -62,6 +64,8 @@ static FIXTURE: &str = r#"
 \@writefile{toc}{\contentsline {section}{\numberline {4}Qux}{1}\protected@file@percent }
 \newlabel{sec:qux}{{4}{1}}
 \newlabel{thm:qux}{{1}{1}}
+\@writefile{toc}{\contentsline {section}{\numberline {5}Foo bar}{1}{}\protected@file@percent }
+\newlabel{sec:foobar}{{5}{1}{}{section.5}{}}
 
 %! main.bib
 @article{foo,}
@@ -149,6 +153,24 @@ fn test_filter_type_section() {
                     ),
                     full_range: 447..557,
                     selection_range: 460..475,
+                    children: [],
+                },
+            },
+            SymbolLocation {
+                document: Document(
+                    "file:///texlab/main.tex",
+                ),
+                symbol: Symbol {
+                    name: "5 Foo bar",
+                    kind: Section,
+                    label: Some(
+                        Span(
+                            "sec:foobar",
+                            576..594,
+                        ),
+                    ),
+                    full_range: 559..594,
+                    selection_range: 576..594,
                     children: [],
                 },
             },
@@ -337,4 +359,66 @@ fn test_filter_bibtex() {
         ]
     "#]],
     );
+}
+
+#[test]
+fn test_name() {
+    check(
+        "fo",
+        expect![[r#"
+            [
+                SymbolLocation {
+                    document: Document(
+                        "file:///texlab/main.tex",
+                    ),
+                    symbol: Symbol {
+                        name: "1 Foo",
+                        kind: Section,
+                        label: Some(
+                            Span(
+                                "sec:foo",
+                                118..133,
+                            ),
+                        ),
+                        full_range: 105..188,
+                        selection_range: 118..133,
+                        children: [],
+                    },
+                },
+                SymbolLocation {
+                    document: Document(
+                        "file:///texlab/main.tex",
+                    ),
+                    symbol: Symbol {
+                        name: "5 Foo bar",
+                        kind: Section,
+                        label: Some(
+                            Span(
+                                "sec:foobar",
+                                576..594,
+                            ),
+                        ),
+                        full_range: 559..594,
+                        selection_range: 576..594,
+                        children: [],
+                    },
+                },
+                SymbolLocation {
+                    document: Document(
+                        "file:///texlab/main.bib",
+                    ),
+                    symbol: Symbol {
+                        name: "foo",
+                        kind: Entry(
+                            Article,
+                        ),
+                        label: None,
+                        full_range: 0..14,
+                        selection_range: 9..12,
+                        children: [],
+                    },
+                },
+            ]
+        "#]],
+    )
 }


### PR DESCRIPTION
This PR changes two things:
- When creating keywords out of symbols for `workspace_search`, symbol names are now split at whitespace and flattened with the tags representing the types. This makes it possible to ever match multi-word symbols, which wasn't possibly until now because the query was whitespace split and the name wasn't. Now they both are.
- Filter the symbols based on any keyword **containing**, not being equal to, any word of the query. This way symbols show up properly as the user types the query without having to fully type out a word for the symbol to pop up.