### PR TITLE
Recognize wide float environments in label parsing

### DIFF
--- a/crates/base-db/src/util/label.rs
+++ b/crates/base-db/src/util/label.rs
@@ -34,10 +34,10 @@ impl FromStr for FloatKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "figure" | "subfigure" => Ok(Self::Figure),
-            "table" | "subtable" => Ok(Self::Table),
-            "listing" | "lstlisting" => Ok(Self::Listing),
-            "algorithm" => Ok(Self::Algorithm),
+            "figure" | "figure*" | "subfigure" => Ok(Self::Figure),
+            "table" | "table*" | "subtable" => Ok(Self::Table),
+            "listing" | "listing*" | "lstlisting" | "lstlisting*" => Ok(Self::Listing),
+            "algorithm" | "algorithm*" => Ok(Self::Algorithm),
             _ => Err(()),
         }
     }

--- a/crates/symbols/src/document/tests.rs
+++ b/crates/symbols/src/document/tests.rs
@@ -196,6 +196,11 @@ fn test_float() {
     \caption{Baz}
 \end{figure}
 
+\begin{figure*}
+    Baz
+    \caption{Baz2}
+\end{figure*}
+
 \begin{figure}
     Qux
 \end{figure}
@@ -247,6 +252,14 @@ fn test_float() {
                 label: None,
                 full_range: 183..236,
                 selection_range: 183..236,
+                children: [],
+            },
+            Symbol {
+                name: "Figure: Baz2",
+                kind: Figure,
+                label: None,
+                full_range: 238..294,
+                selection_range: 238..294,
                 children: [],
             },
         ]


### PR DESCRIPTION
Currently it renders as section or subsection

<img width="547" alt="image" src="https://github.com/user-attachments/assets/053f28d2-ed91-4856-89cb-ba91aec63077" />
