### PR TITLE
Fix multi-file project detection algorithm when using includefrom

### DIFF
--- a/crates/parser/src/latex/lexer/commands.rs
+++ b/crates/parser/src/latex/lexer/commands.rs
@@ -26,7 +26,7 @@ pub fn classify(name: &str, config: &SyntaxConfig) -> CommandName {
         "includesvg" => CommandName::SvgInclude,
         "includeinkscape" => CommandName::InkscapeInclude,
         "verbatiminput" | "VerbatimInput" => CommandName::VerbatimInclude,
-        "import" | "subimport" | "inputfrom" | "subinputfrom" | "subincludefrom" => {
+        "import" | "subimport" | "inputfrom" | "subinputfrom" | "includefrom" | "subincludefrom" => {
             CommandName::Import
         }
         "newlabel" => CommandName::LabelNumber,


### PR DESCRIPTION
`texlab` list of commands for including files within a latex document is missing the `includefrom` command defined by the `subimport` module, causing `texlab`'s project detection algorithm to break when using these files. This PR simply adds `includefrom` to this list.