### PR TITLE
Install musl-tools in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cross-compilation dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf musl-tools
         if: ${{ matrix.os == 'ubuntu-22.04' }}
       - name: Compile
         run: cargo test --target ${{ matrix.target }} --all-features --no-run --locked

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install cross-compilation dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf musl-tools
         if: ${{ matrix.os == 'ubuntu-22.04' }}
       - name: Compile
         run: cargo build --target ${{ matrix.target }} --all-features --release --locked


### PR DESCRIPTION
musl-tools is need to compile newer versions of criterion on musl.