### PR TITLE
Use std::hint::black_box

### DIFF
--- a/crates/texlab/benches/bench_main.rs
+++ b/crates/texlab/benches/bench_main.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use parser::{SyntaxConfig, parse_latex};
 
 const CODE: &str = include_str!("../../../texlab.tex");


### PR DESCRIPTION
criterion::black_box is deprecated.