### PR TITLE
Run latexindent from server process CWD

### DIFF
--- a/crates/texlab/src/features/formatting/latexindent.rs
+++ b/crates/texlab/src/features/formatting/latexindent.rs
@@ -1,9 +1,10 @@
 use std::{
+    env,
     path::Path,
     process::{Command, Stdio},
 };
 
-use base_db::{Document, LatexIndentConfig, Workspace, deps::ProjectRoot};
+use base_db::{Document, LatexIndentConfig, Workspace};
 use distro::Language;
 use rowan::TextLen;
 use tempfile::tempdir;
@@ -16,8 +17,6 @@ pub fn format_with_latexindent(
 ) -> Option<Vec<lsp_types::TextEdit>> {
     let config = workspace.config();
     let target_dir = tempdir().ok()?;
-    let root = ProjectRoot::walk_and_find(workspace, document.dir.as_ref()?);
-    let source_dir = root.src_dir.to_file_path().ok()?;
 
     let target_file = target_dir
         .path()
@@ -31,8 +30,8 @@ pub fn format_with_latexindent(
     let args = build_arguments(&config.formatting.latex_indent, &target_file);
 
     log::debug!(
-        "Running latexindent in folder \"{}\" with args: {:?}",
-        source_dir.display(),
+        "Running latexindent in folder {:?} with args: {:?}",
+        env::current_dir(),
         args,
     );
 
@@ -41,7 +40,6 @@ pub fn format_with_latexindent(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .current_dir(source_dir)
         .output()
         .ok()?;
 


### PR DESCRIPTION
An attempt to close #1345

Currently, when spawning latexindent, the directory of the document is used as the working directory for the subprocess: https://github.com/latex-lsp/texlab/blob/d89bf0fa65bd931ab57183d067f66189fc31e6c9/crates/texlab/src/features/formatting/latexindent.rs#L19-L20
I am not sure if the `Document` type is referring to a latex file that I would compile, or if it means "any latex file, even if only used by \input in another". If the former, then we should not have `content/sec.tex` be a Document in the first place. As far as I understand the code though, I suspect that the latter is what a Document actually is here.

Either way, this means that with a setup like the following, when editing `content/sec.tex`, latexindent will _not_ use the localSettings.yaml file:
```plain
.
├── content
│   └── sec.tex
├── doc.tex
├── localSettings.yaml
```
In such a setup I run `latexindent` using something like `latexindent --local -wd **/*.tex`, and everything works because the yaml file is also picked up from the current directory:
```
$ latexindent --help
latexindent.pl version 3.24.5, 2025-03-13
usage: latexindent.pl [options] [file]
      [...]
      -l, --local[=myyaml.yaml]
          use `localSettings.yaml`, `.localSettings.yaml`, `latexindent.yaml`,
          or `.latexindent.yaml` (assuming one of them exists in the directory of your file or in
          the current working directory); alternatively, use `myyaml.yaml`, if it exists;
```

Thus, when spawning latexindent from texlab, I would expect that the LSP root is used.

My proposed fix is to not set the working directory for the child directory at all. Then the working directory of the parent process is kept and latexindent picks up on the `localSettings.yaml` file in it.
