### PR TITLE
Send TextEdit only if latexindent changed something

### DIFF
--- a/crates/texlab/src/features/formatting/latexindent.rs
+++ b/crates/texlab/src/features/formatting/latexindent.rs
@@ -49,6 +49,9 @@ pub fn format_with_latexindent(
     let new_text = String::from_utf8_lossy(&output.stdout).into_owned();
     if new_text.is_empty() {
         None
+    } else if new_text == *old_text {
+        // No edits needed
+        return Some(Vec::new());
     } else {
         let line_index = &document.line_index;
         let start = lsp_types::Position::new(0, 0);


### PR DESCRIPTION
I noticed that when formatting files in neovim, the buffer would always be marked as dirty, even if formatting did not change anything.

I changed the latexindent formatting logic to emit an empty list of `TextEdit`s if the old and new text are equal. I considered merging it with the `if new_text.is_empty()` branch, but it seemed to me like that is more of an error case. I don't know about LSP conventions though, so let me know if returning None is more appropriate.
