### PR TITLE
feat(definition): add goto_definition for acronym commands

### DIFF
--- a/crates/definition/src/acronym.rs
+++ b/crates/definition/src/acronym.rs
@@ -1,0 +1,79 @@
+use base_db::DocumentData;
+use rowan::{TextRange, ast::AstNode};
+use syntax::latex;
+
+use crate::DefinitionContext;
+
+use super::DefinitionResult;
+
+pub(super) fn goto_definition(context: &mut DefinitionContext) -> Option<()> {
+    let feature = &context.params.feature;
+    let data = feature.document.data.as_tex()?;
+    let root = data.root_node();
+
+    // Find the token at the cursor position
+    let token = root.token_at_offset(context.params.offset).right_biased()?;
+
+    // Walk up ancestors to find a CurlyGroupWord whose parent is an AcronymReference
+    let name_group = token
+        .parent_ancestors()
+        .find_map(latex::CurlyGroupWord::cast)?;
+    latex::AcronymReference::cast(name_group.syntax().parent()?)?;
+
+    let key = name_group.key()?;
+    let key_text = key.to_string();
+    let origin_selection_range = latex::small_range(&name_group);
+
+    // Search all project documents for acronym definitions
+    for document in &feature.project.documents {
+        let DocumentData::Tex(data) = &document.data else {
+            continue;
+        };
+
+        let results = data
+            .root_node()
+            .descendants()
+            .filter_map(|node| {
+                process_definition(node.clone(), &key_text)
+                    .or_else(|| process_declaration(node, &key_text))
+            })
+            .map(|(target_range, target_selection_range)| DefinitionResult {
+                origin_selection_range,
+                target: document,
+                target_range,
+                target_selection_range,
+            });
+
+        context.results.extend(results);
+    }
+
+    Some(())
+}
+
+fn process_definition(
+    node: latex::SyntaxNode,
+    key: &str,
+) -> Option<(TextRange, TextRange)> {
+    let def = latex::AcronymDefinition::cast(node)?;
+    let name = def.name()?;
+    let name_key = name.key()?;
+    if name_key.to_string() == key {
+        Some((latex::small_range(&def), latex::small_range(&name)))
+    } else {
+        None
+    }
+}
+
+fn process_declaration(
+    node: latex::SyntaxNode,
+    key: &str,
+) -> Option<(TextRange, TextRange)> {
+    let decl = latex::AcronymDeclaration::cast(node)?;
+    let name = decl.name()?;
+    let name_key = name.key()?;
+    if name_key.to_string() == key {
+        Some((latex::small_range(&decl), latex::small_range(&name)))
+    } else {
+        None
+    }
+}

--- a/crates/definition/src/lib.rs
+++ b/crates/definition/src/lib.rs
@@ -1,3 +1,4 @@
+mod acronym;
 mod citation;
 mod command;
 mod include;
@@ -39,6 +40,7 @@ pub fn goto_definition<'a>(params: &DefinitionParams<'a>) -> FxHashSet<Definitio
     citation::goto_definition(&mut context);
     label::goto_definition(&mut context);
     string_ref::goto_definition(&mut context);
+    acronym::goto_definition(&mut context);
     context.results
 }
 

--- a/crates/definition/src/tests.rs
+++ b/crates/definition/src/tests.rs
@@ -154,3 +154,58 @@ fn test_string_field() {
                 |"#,
     )
 }
+
+#[test]
+fn test_acronym_definition() {
+    check(
+        r#"
+%! main.tex
+\newacronym{fps}{FPS}{Frames}
+           ^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+\acrshort{fps}
+          |
+         ^^^^^"#,
+    )
+}
+
+#[test]
+fn test_acronym_declaration() {
+    check(
+        r#"
+%! main.tex
+\DeclareAcronym{eg}{short=eg}
+               ^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+\acrshort{eg}
+          |
+         ^^^^"#,
+    )
+}
+
+#[test]
+fn test_acronym_cross_file() {
+    check(
+        r#"
+%! main.tex
+\input{acronyms}
+\acrshort{fps}
+          |
+         ^^^^^
+
+%! acronyms.tex
+\newacronym{fps}{FPS}{Frames}
+           ^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"#,
+    )
+}
+
+#[test]
+fn test_acronym_no_definition() {
+    check(
+        r#"
+%! main.tex
+\acrshort{unknown}
+           |"#,
+    )
+}

--- a/crates/syntax/src/latex/cst.rs
+++ b/crates/syntax/src/latex/cst.rs
@@ -642,6 +642,10 @@ impl AcronymReference {
     pub fn command(&self) -> Option<SyntaxToken> {
         self.syntax().first_token()
     }
+
+    pub fn name(&self) -> Option<CurlyGroupWord> {
+        self.syntax().children().find_map(CurlyGroupWord::cast)
+    }
 }
 
 cst_node!(AcronymDefinition, ACRONYM_DEFINITION);


### PR DESCRIPTION
Enable goto_definition for acronym reference commands (\acrshort, \acrlong, \acrfull, \ac, and all variants) to resolve to their definitions (\newacronym, \DeclareAcronym).

## Disclaimer
Full disclaimer: most of the code was generated using generative AI (Claude Code Opus 4.6), hence the co-author being Claude. 

I reviewed it to the best of my abilities and tested it in the field using my setup of choice (helix 25.07.1 (a05c151b)).
