### PR TITLE
Fix publishing on CTAN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
   ctan:
     name: CTAN
     needs: [github]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Bump Ubuntu version to 24.04 LTS so that tectonic can compile the PDF documentation required by CTAN.