### PR TITLE
Use diagnostics delay to debounce updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Use `texlab.diagnosticsDelay` to debounce diagnostics updates with the goal of reducing load of the client
+  ([#1551](https://github.com/latex-lsp/texlab/issues/1551))
+
 ## [5.26.0] - 2026-06-25
 
 ### Added

--- a/crates/definition/src/acronym.rs
+++ b/crates/definition/src/acronym.rs
@@ -50,10 +50,7 @@ pub(super) fn goto_definition(context: &mut DefinitionContext) -> Option<()> {
     Some(())
 }
 
-fn process_definition(
-    node: latex::SyntaxNode,
-    key: &str,
-) -> Option<(TextRange, TextRange)> {
+fn process_definition(node: latex::SyntaxNode, key: &str) -> Option<(TextRange, TextRange)> {
     let def = latex::AcronymDefinition::cast(node)?;
     let name = def.name()?;
     let name_key = name.key()?;
@@ -64,10 +61,7 @@ fn process_definition(
     }
 }
 
-fn process_declaration(
-    node: latex::SyntaxNode,
-    key: &str,
-) -> Option<(TextRange, TextRange)> {
+fn process_declaration(node: latex::SyntaxNode, key: &str) -> Option<(TextRange, TextRange)> {
     let decl = latex::AcronymDeclaration::cast(node)?;
     let name = decl.name()?;
     let name_key = name.key()?;

--- a/crates/texlab/src/server.rs
+++ b/crates/texlab/src/server.rs
@@ -1,3 +1,4 @@
+mod diagnostics_publisher;
 mod dispatch;
 mod extensions;
 pub mod options;
@@ -37,6 +38,7 @@ use crate::{
 };
 
 use self::{
+    diagnostics_publisher::{DiagnosticsPublisher, PublishToken},
     extensions::{
         BuildParams, BuildRequest, BuildResult, BuildStatus, EnvironmentLocation,
         ForwardSearchRequest, ForwardSearchResult, ForwardSearchStatus, TextWithRange,
@@ -50,7 +52,7 @@ enum InternalMessage {
     SetDistro(Distro),
     SetOptions(Box<Options>),
     FileEvent(Vec<DebouncedEvent>),
-    Diagnostics,
+    Diagnostics(PublishToken),
     ChktexFinished(Url, Vec<diagnostics::Diagnostic>),
     ForwardSearch(Url, Option<Position>),
     InverseSearch(TextDocumentPositionParams),
@@ -70,7 +72,7 @@ pub struct Server {
     client: LspClient,
     client_flags: Arc<ClientFlags>,
     diagnostic_manager: diagnostics::Manager,
-    published_diagnostics: FxHashSet<Url>,
+    diagnostics_publisher: DiagnosticsPublisher,
     watcher: FileWatcher,
     pool: ThreadPool,
     pending_builds: Arc<Mutex<FxHashSet<u32>>>,
@@ -119,7 +121,7 @@ impl Server {
                 params.client_info,
             )),
             diagnostic_manager: diagnostics::Manager::default(),
-            published_diagnostics: FxHashSet::default(),
+            diagnostics_publisher: DiagnosticsPublisher::default(),
             watcher,
             pool: threadpool::Builder::new().build(),
             pending_builds: Default::default(),
@@ -272,26 +274,14 @@ impl Server {
 
     fn publish_diagnostics(&mut self) -> Result<()> {
         let workspace = self.workspace.read();
-
-        for params in collect_publish_diagnostics(
-            &workspace,
-            &self.diagnostic_manager,
-            &mut self.published_diagnostics,
-        ) {
-            self.client
-                .send_notification::<PublishDiagnostics>(params)?;
-        }
-
-        Ok(())
+        self.diagnostics_publisher
+            .publish(&self.client, &workspace, &self.diagnostic_manager)
     }
 
     fn publish_diagnostics_with_delay(&mut self) {
-        let sender = self.internal_tx.clone();
         let delay = self.workspace.read().config().diagnostics.delay;
-        self.pool.execute(move || {
-            std::thread::sleep(delay);
-            sender.send(InternalMessage::Diagnostics).unwrap();
-        });
+        self.diagnostics_publisher
+            .schedule(&self.internal_tx, &self.pool, delay);
     }
 
     fn pull_options(&mut self) {
@@ -1098,8 +1088,10 @@ impl Server {
                                 self.handle_file_event(event);
                             }
                         }
-                        InternalMessage::Diagnostics => {
-                            self.publish_diagnostics()?;
+                        InternalMessage::Diagnostics(token) => {
+                            if self.diagnostics_publisher.should_publish(token) {
+                                self.publish_diagnostics()?;
+                            }
                         }
                         InternalMessage::ChktexFinished(uri, diagnostics) => {
                             self.diagnostic_manager.update_chktex(uri, diagnostics);
@@ -1151,47 +1143,6 @@ impl Server {
         self.pool.join();
         Ok(())
     }
-}
-
-fn collect_publish_diagnostics(
-    workspace: &Workspace,
-    diagnostic_manager: &diagnostics::Manager,
-    published_diagnostics: &mut FxHashSet<Url>,
-) -> Vec<PublishDiagnosticsParams> {
-    let mut params = Vec::new();
-    let current_diagnostics = diagnostic_manager.get(workspace);
-    let current_uris = current_diagnostics
-        .keys()
-        .cloned()
-        .collect::<FxHashSet<_>>();
-
-    for (uri, diagnostics) in current_diagnostics {
-        let Some(document) = workspace.lookup(&uri) else {
-            continue;
-        };
-
-        let diagnostics = diagnostics
-            .into_iter()
-            .filter_map(|diagnostic| to_proto::diagnostic(workspace, document, &diagnostic))
-            .collect();
-
-        params.push(PublishDiagnosticsParams {
-            uri: to_proto::uri(&uri),
-            diagnostics,
-            version: None,
-        });
-    }
-
-    for uri in published_diagnostics.difference(&current_uris) {
-        params.push(PublishDiagnosticsParams {
-            uri: to_proto::uri(uri),
-            diagnostics: Vec::new(),
-            version: None,
-        });
-    }
-
-    *published_diagnostics = current_uris;
-    params
 }
 
 fn handle_path_change(

--- a/crates/texlab/src/server/diagnostics_publisher.rs
+++ b/crates/texlab/src/server/diagnostics_publisher.rs
@@ -1,0 +1,136 @@
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use anyhow::Result;
+use base_db::Workspace;
+use crossbeam_channel::Sender;
+use lsp_types::{PublishDiagnosticsParams, notification::PublishDiagnostics};
+use rustc_hash::FxHashSet;
+use threadpool::ThreadPool;
+use url::Url;
+
+use crate::{client::LspClient, util::to_proto};
+
+use super::InternalMessage;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PublishToken(u64);
+
+#[derive(Debug, Default)]
+pub(super) struct DiagnosticsPublisher {
+    next_token: AtomicU64,
+    pending_token: Option<PublishToken>,
+    published_diagnostics: FxHashSet<Url>,
+}
+
+impl DiagnosticsPublisher {
+    pub(super) fn schedule(
+        &mut self,
+        sender: &Sender<InternalMessage>,
+        pool: &ThreadPool,
+        delay: Duration,
+    ) {
+        let token = self.schedule_token();
+        let sender = sender.clone();
+
+        pool.execute(move || {
+            std::thread::sleep(delay);
+            sender.send(InternalMessage::Diagnostics(token)).unwrap();
+        });
+    }
+
+    pub(super) fn should_publish(&mut self, token: PublishToken) -> bool {
+        if self.pending_token == Some(token) {
+            self.pending_token = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(super) fn publish(
+        &mut self,
+        client: &LspClient,
+        workspace: &Workspace,
+        diagnostic_manager: &diagnostics::Manager,
+    ) -> Result<()> {
+        for params in self.collect(workspace, diagnostic_manager) {
+            client.send_notification::<PublishDiagnostics>(params)?;
+        }
+
+        Ok(())
+    }
+
+    fn schedule_token(&mut self) -> PublishToken {
+        let token = PublishToken(self.next_token.fetch_add(1, Ordering::Relaxed));
+        self.pending_token = Some(token);
+        token
+    }
+
+    fn collect(
+        &mut self,
+        workspace: &Workspace,
+        diagnostic_manager: &diagnostics::Manager,
+    ) -> Vec<PublishDiagnosticsParams> {
+        let mut params = Vec::new();
+        let current_diagnostics = diagnostic_manager.get(workspace);
+        let current_uris = current_diagnostics
+            .keys()
+            .cloned()
+            .collect::<FxHashSet<_>>();
+
+        for (uri, diagnostics) in current_diagnostics {
+            let Some(document) = workspace.lookup(&uri) else {
+                continue;
+            };
+
+            let diagnostics = diagnostics
+                .into_iter()
+                .filter_map(|diagnostic| to_proto::diagnostic(workspace, document, &diagnostic))
+                .collect();
+
+            params.push(PublishDiagnosticsParams {
+                uri: to_proto::uri(&uri),
+                diagnostics,
+                version: None,
+            });
+        }
+
+        for uri in self.published_diagnostics.difference(&current_uris) {
+            params.push(PublishDiagnosticsParams {
+                uri: to_proto::uri(uri),
+                diagnostics: Vec::new(),
+                version: None,
+            });
+        }
+
+        self.published_diagnostics = current_uris;
+        params
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiagnosticsPublisher;
+
+    #[test]
+    fn test_stale_scheduled_publishes_are_ignored() {
+        let mut publisher = DiagnosticsPublisher::default();
+        let first = publisher.schedule_token();
+        let second = publisher.schedule_token();
+
+        assert!(!publisher.should_publish(first));
+        assert!(publisher.should_publish(second));
+    }
+
+    #[test]
+    fn test_pending_publish_is_consumed_once() {
+        let mut publisher = DiagnosticsPublisher::default();
+        let token = publisher.schedule_token();
+
+        assert!(publisher.should_publish(token));
+        assert!(!publisher.should_publish(token));
+    }
+}


### PR DESCRIPTION
Use `texlab.diagnosticsDelay` to debounce `textDocument/publishDiagnostics` messages coming from the server.

Previously, events were only delayed but no debouncing was done.

Fixes #1551.