### PR TITLE
Update visit_beamer_frame() frame title logic

### DIFF
--- a/crates/symbols/src/document/tests.rs
+++ b/crates/symbols/src/document/tests.rs
@@ -783,3 +783,55 @@ Frame 2 content.
         "#]],
     );
 }
+
+#[test]
+fn test_beamer_frame_title_argument_1525() {
+    let fixture = Fixture::parse(
+        r#"
+%! main.tex
+\documentclass{beamer}
+\begin{document}
+
+\section{A section}
+
+\begin{frame}{Frame Title}
+	Test frame
+\end{frame}
+
+\begin{frame}{Frame Title 2}
+	Test frame 2
+\end{frame}
+
+\end{document}"#,
+    );
+
+    check(&fixture, expect![[r#"
+        [
+            Symbol {
+                name: "A section",
+                kind: Section,
+                label: None,
+                full_range: 41..168,
+                selection_range: 41..168,
+                children: [
+                    Symbol {
+                        name: "Frame: Frame Title",
+                        kind: BeamerFrame,
+                        label: None,
+                        full_range: 62..112,
+                        selection_range: 62..112,
+                        children: [],
+                    },
+                    Symbol {
+                        name: "Frame: Frame Title 2",
+                        kind: BeamerFrame,
+                        label: None,
+                        full_range: 114..168,
+                        selection_range: 114..168,
+                        children: [],
+                    },
+                ],
+            },
+        ]
+    "#]]);
+}

--- a/crates/symbols/src/document/tests.rs
+++ b/crates/symbols/src/document/tests.rs
@@ -792,45 +792,92 @@ fn test_beamer_frame_title_argument_1525() {
 \documentclass{beamer}
 \begin{document}
 
-\section{A section}
-
-\begin{frame}{Frame Title}
-	Test frame
+\begin{frame}{Numbered Title}\label{frame:num}
+Body.
 \end{frame}
 
-\begin{frame}{Frame Title 2}
-	Test frame 2
+\begin{frame}{Unnumbered Title}\label{frame:nonum}
+Body.
 \end{frame}
 
-\end{document}"#,
+\begin{frame}\label{frame:notitle}
+Body.
+\end{frame}
+
+\begin{frame}
+Body.
+\end{frame}
+
+\begin{frame}{a title}
+\frametitle{Expected Title}
+Body.
+\end{frame}
+
+\end{document}
+
+%! main.aux
+\relax
+\newlabel{frame:num}{{1}{1}}
+\newlabel{frame:notitle}{{2}{1}}
+"#,
     );
 
     check(&fixture, expect![[r#"
         [
             Symbol {
-                name: "A section",
-                kind: Section,
+                name: "Frame 1: Numbered Title",
+                kind: BeamerFrame,
+                label: Some(
+                    Span(
+                        "frame:num",
+                        70..87,
+                    ),
+                ),
+                full_range: 41..105,
+                selection_range: 70..87,
+                children: [],
+            },
+            Symbol {
+                name: "Frame: Unnumbered Title",
+                kind: BeamerFrame,
+                label: Some(
+                    Span(
+                        "frame:nonum",
+                        138..157,
+                    ),
+                ),
+                full_range: 107..175,
+                selection_range: 138..157,
+                children: [],
+            },
+            Symbol {
+                name: "Frame 2",
+                kind: BeamerFrame,
+                label: Some(
+                    Span(
+                        "frame:notitle",
+                        190..211,
+                    ),
+                ),
+                full_range: 177..229,
+                selection_range: 190..211,
+                children: [],
+            },
+            Symbol {
+                name: "Frame",
+                kind: BeamerFrame,
                 label: None,
-                full_range: 41..168,
-                selection_range: 41..168,
-                children: [
-                    Symbol {
-                        name: "Frame: Frame Title",
-                        kind: BeamerFrame,
-                        label: None,
-                        full_range: 62..112,
-                        selection_range: 62..112,
-                        children: [],
-                    },
-                    Symbol {
-                        name: "Frame: Frame Title 2",
-                        kind: BeamerFrame,
-                        label: None,
-                        full_range: 114..168,
-                        selection_range: 114..168,
-                        children: [],
-                    },
-                ],
+                full_range: 231..262,
+                selection_range: 231..262,
+                children: [],
+            },
+            Symbol {
+                name: "Frame: Expected Title",
+                kind: BeamerFrame,
+                label: None,
+                full_range: 264..332,
+                selection_range: 264..332,
+                children: [],
             },
         ]
     "#]]);

--- a/crates/symbols/src/document/tex.rs
+++ b/crates/symbols/src/document/tex.rs
@@ -264,24 +264,23 @@ impl<'a> SymbolBuilder<'a> {
     fn visit_beamer_frame(&self, environment: &latex::Environment) -> Option<Symbol> {
         let range = latex::small_range(environment);
 
-        let caption = find_caption(environment)?;
+        let title = find_frame_title(environment);
+        let label = self.find_label(environment.syntax());
+        let number = label
+            .as_ref()
+            .and_then(|label| self.find_label_number(&label.text));
 
-        let symbol = match self.find_label(environment.syntax()) {
-            Some(label) => {
-                let name = match self.find_label_number(&label.text) {
-                    Some(number) => format!("Frame {number}: {caption}"),
-                    None => format!("Frame: {caption}"),
-                };
-
-                Symbol::new_label(name, SymbolKind::BeamerFrame, range, label)
-            }
-            None => {
-                let name = format!("Frame: {caption}");
-                Symbol::new_simple(name, SymbolKind::BeamerFrame, range, range)
-            }
+        let name = match (number, title) {
+            (Some(number), Some(title)) => format!("Frame {number}: {title}"),
+            (Some(number), None) => format!("Frame {number}"),
+            (None, Some(title)) => format!("Frame: {title}"),
+            (None, None) => "Frame".into(),
         };
 
-        Some(symbol)
+        Some(match label {
+            Some(label) => Symbol::new_label(name, SymbolKind::BeamerFrame, range, label),
+            None => Symbol::new_simple(name, SymbolKind::BeamerFrame, range, range),
+        })
     }
 
     fn visit_environment(
@@ -336,6 +335,20 @@ impl<'a> SymbolBuilder<'a> {
             .filter_map(|document| document.data.as_aux())
             .find_map(|data| data.semantics.label_numbers.get(name))
             .map(String::as_str)
+    }
+}
+
+fn find_frame_title(environment: &latex::Environment) -> Option<String> {
+    let title = find_caption(environment);
+    if title.is_some() {
+        title
+    } else {
+        environment
+            .begin()?
+            .syntax()
+            .next_sibling()
+            .and_then(latex::CurlyGroup::cast)
+            .and_then(|group| group.content_text())
     }
 }
 


### PR DESCRIPTION
Currently `visit_beamer_frame(...)` early returns `None` if no `\frametitle` command is found in the environment.

This PR updates `visit_beamer_frame(...)` to handle cases when there is an optional title argument e.g. `\begin{frame}{title}` or when no title is specified. A `\frametitle` command takes precedence here (as it does in latex). The optional environment argument is the fallback if no `\frametitle` is found, and if neither are present an untitled `Frame` symbol is still returned. The function has no path that can return `None`, but I have left the return type as an `Option` to match the pattern used at the call site. A helper function for extracting the title and a test to exercise the symbol name logic are provided.

resolves #1525